### PR TITLE
Render loading spinner for audio tags

### DIFF
--- a/src/shared/components/AudioRecordingPreview.tsx
+++ b/src/shared/components/AudioRecordingPreview.tsx
@@ -1,16 +1,21 @@
 import React, { useState, ReactElement } from 'react';
 import { Record } from 'react-admin';
-import { Box, Tag } from '@chakra-ui/react';
+import { Box, Spinner, Tag } from '@chakra-ui/react';
 
 const AudioRecordingPreview = (
   { record }:
   { record: { pronunciation: string } | Record },
 ): ReactElement => {
   const audio = new Audio(record.pronunciation);
+  const [isLoading, setIsLoading] = useState(true);
   const [isAudioAvailable, setIsAudioAvailable] = useState(false);
-
   audio.addEventListener('canplay', () => {
     setIsAudioAvailable(true);
+    setIsLoading(false);
+  });
+  audio.addEventListener('error', () => {
+    setIsAudioAvailable(false);
+    setIsLoading(false);
   });
 
   const playAudio = () => {
@@ -25,7 +30,7 @@ const AudioRecordingPreview = (
           onClick={playAudio}
           type="button"
         >
-          {!isAudioAvailable ? 'Rerecord audio' : '🎙 Play'}
+          {isLoading ? <Spinner /> : !isAudioAvailable ? 'Rerecord audio' : '🎙 Play'}
         </Tag>
       ) : (
         <Tag colorScheme="red" className="text-center">No Recording</Tag>


### PR DESCRIPTION
## Background
For slower internet connections, the Rerecord audio tag seemed to be the final state to translators and recorders. However, that's not the case since the Rerecord audio tag would sit there until the Audio class was finally able to load the data for the audio playback.

This PR listens to the `onerror` event in order for the platform to either render the loading state, rerecord label, or play label.