### PR TITLE
Add support for active and passive verbs

### DIFF
--- a/src/backend/shared/constants/WordClass.ts
+++ b/src/backend/shared/constants/WordClass.ts
@@ -10,9 +10,13 @@ const WordClass = {
     value: 'ADV',
     label: 'Adverb',
   },
-  V: {
-    value: 'V',
-    label: 'Verb',
+  AV: {
+    value: 'AV',
+    label: 'Active verb',
+  },
+  PV: {
+    value: 'PV',
+    label: 'Passive verb',
   },
   CJN: {
     value: 'CJN',
@@ -24,7 +28,7 @@ const WordClass = {
   },
   NM: {
     value: 'NM',
-    name: 'Name',
+    label: 'Name',
   },
   NNC: {
     value: 'NNC',

--- a/src/shared/constants/WordClass.ts
+++ b/src/shared/constants/WordClass.ts
@@ -10,9 +10,13 @@ const WordClass = {
     value: 'ADV',
     label: 'Adverb',
   },
-  V: {
-    value: 'V',
-    label: 'Verb',
+  AV: {
+    value: 'AV',
+    label: 'Active verb',
+  },
+  PV: {
+    value: 'PV',
+    label: 'Passive verb',
   },
   CJN: {
     value: 'CJN',


### PR DESCRIPTION
## Background
Editors have requested that the platform exposes the difference between verbs by introducing active and passive verbs. This PR adds these new word classes by replacing the legacy verb word class.