### PR TITLE
Render Is Complete checkbox and update backend logic

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "precommit": "lint-staged"
   },
   "engines": {
-    "node": "12"
+    "node": "<=16"
   },
   "author": "",
   "husky": {

--- a/src/backend/controllers/stats.ts
+++ b/src/backend/controllers/stats.ts
@@ -69,18 +69,23 @@ export const getCompleteWords = async (
       isStandardIgbo,
       pronunciation,
       examples,
-    }) => (
-      word
-      // String normalization check:
-      // https://www.codegrepper.com/code-examples/javascript/check+if+word+has+accented+or+unaccented+javascript
-      // Filtering character in regex code: https://regex101.com/r/mL0eG4/1
-      && word.normalize('NFD').match(/(?!\u0323)[\u0300-\u036f]/g)
-      && wordClass
-      && Array.isArray(definitions) && definitions.length >= 1
-      && Array.isArray(examples) && examples.length >= 1
-      && pronunciation.length > 10
-      && isStandardIgbo
-    )).length;
+      isComplete,
+    }) => {
+      const automaticCheck = (
+        word
+        // String normalization check:
+        // https://www.codegrepper.com/code-examples/javascript/check+if+word+has+accented+or+unaccented+javascript
+        // Filtering character in regex code: https://regex101.com/r/mL0eG4/1
+        && word.normalize('NFD').match(/(?!\u0323)[\u0300-\u036f]/g)
+        && wordClass
+        && Array.isArray(definitions) && definitions.length >= 1
+        && Array.isArray(examples) && examples.length >= 1
+        && pronunciation.length > 10
+        && isStandardIgbo
+      );
+      const manualCheck = isComplete;
+      return automaticCheck || manualCheck;
+    }).length;
     return res.send({ count });
   } catch (err) {
     return next(err);

--- a/src/backend/controllers/utils/buildDocs.ts
+++ b/src/backend/controllers/utils/buildDocs.ts
@@ -91,6 +91,7 @@ export const findWordsWithMatch = async (
       antonyms: 1,
       hypernyms: 1,
       hyponyms: 1,
+      isComplete: 1,
       ...(examples ? { examples: 1 } : {}),
     })
     .skip(skip)

--- a/src/backend/models/Word.ts
+++ b/src/backend/models/Word.ts
@@ -32,6 +32,7 @@ const wordSchema = new Schema({
   antonyms: { type: [{ type: Types.ObjectId, ref: 'Word' }], default: [] },
   hypernyms: { type: [{ type: Types.ObjectId, ref: 'Word' }], default: [] },
   hyponyms: { type: [{ type: Types.ObjectId, ref: 'Word' }], default: [] },
+  isComplete: { type: Boolean, default: false },
   updatedOn: { type: Date, default: Date.now() },
 }, { toObject: toObjectPlugin, timestamps: true });
 

--- a/src/backend/models/WordSuggestion.ts
+++ b/src/backend/models/WordSuggestion.ts
@@ -55,6 +55,7 @@ const wordSuggestionSchema = new Schema(
     hyponyms: { type: [{ type: Types.ObjectId, ref: 'Word' }], default: [] },
     approvals: { type: [{ type: String }], default: [] },
     denials: { type: [{ type: String }], default: [] },
+    isComplete: { type: Boolean, default: false },
     updatedOn: { type: Date, default: Date.now() },
     merged: { type: Types.ObjectId, ref: 'Word', default: null },
     mergedBy: { type: String, default: null },

--- a/src/shared/components/CompleteWordPreview.tsx
+++ b/src/shared/components/CompleteWordPreview.tsx
@@ -10,7 +10,7 @@ import {
 } from '@chakra-ui/react';
 
 const CompleteWordPreview = (
-  { record, className }:
+  { record, className, showFull }:
   { record: {
     word: string,
     wordClass: string,
@@ -21,6 +21,7 @@ const CompleteWordPreview = (
     isComplete: boolean,
   } | Record,
   className: string,
+  showFull: boolean,
   },
 ): ReactElement => {
   const {
@@ -41,6 +42,7 @@ const CompleteWordPreview = (
     !pronunciation && 'An audio pronunciation is needed',
     !isStandardIgbo && 'The headword needs to be marked as Standard Igbo',
   ]);
+  const requirementsColor = isComplete ? 'orange.700' : 'red.400';
   return (
     <Box data-test="pronunciation-cell" className={className}>
       <Tooltip
@@ -49,22 +51,25 @@ const CompleteWordPreview = (
       >
         {completeWordRequirements.length ? (
           <Box data-test="incomplete-word-label">
-            <UnorderedList>
-              {completeWordRequirements.length > 2 ? (
-                <>
-                  <ListItem color="red.400">{completeWordRequirements[0]}</ListItem>
-                  <ListItem color="red.400">{completeWordRequirements[1]}</ListItem>
-                  <ListItem color="red.400" fontWeight="bold">
-                    {`${completeWordRequirements.length - 2} more 
-                    field${completeWordRequirements.length - 2 === 1 ? '' : 's'} necessary`}
-                  </ListItem>
-                </>
-              ) : (
-                completeWordRequirements.map((requirement) => (
-                  <ListItem color="red.400">{requirement}</ListItem>
-                ))
-              )}
-            </UnorderedList>
+            {isComplete ? <Text color="green.600">This word is manually set to complete</Text> : null}
+            {showFull || !isComplete ? (
+              <UnorderedList>
+                {completeWordRequirements.length > 2 ? (
+                  <>
+                    <ListItem color={requirementsColor}>{completeWordRequirements[0]}</ListItem>
+                    <ListItem color={requirementsColor}>{completeWordRequirements[1]}</ListItem>
+                    <ListItem color={requirementsColor} fontWeight="bold">
+                      {`${completeWordRequirements.length - 2} more 
+                      field${completeWordRequirements.length - 2 === 1 ? '' : 's'} necessary`}
+                    </ListItem>
+                  </>
+                ) : (
+                  completeWordRequirements.map((requirement) => (
+                    <ListItem color={requirementsColor}>{requirement}</ListItem>
+                  ))
+                )}
+              </UnorderedList>
+            ) : null}
           </Box>
         ) : <Text data-test="complete-word-label" color="green.400">This word is complete</Text>}
       </Tooltip>

--- a/src/shared/components/views/components/WordEditForm/WordEditFormResolver.ts
+++ b/src/shared/components/views/components/WordEditForm/WordEditFormResolver.ts
@@ -34,6 +34,7 @@ const schema = yup.object().shape({
     id: yup.string().optional(),
     originalExampleId: yup.string().nullable().optional(),
   })),
+  isComplete: yup.boolean(),
 });
 
 const resolver = (): any => ({

--- a/src/shared/components/views/components/WordEditForm/components/HeadwordForm/HeadwordForm.tsx
+++ b/src/shared/components/views/components/WordEditForm/components/HeadwordForm/HeadwordForm.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement } from 'react';
-import { Box, Checkbox } from '@chakra-ui/react';
+import { Box, Checkbox, Tooltip } from '@chakra-ui/react';
 import { Controller } from 'react-hook-form';
 import { Input } from '../../../../../../primitives';
 import FormHeader from '../../../FormHeader';
@@ -10,50 +10,87 @@ const HeadwordForm = ({
   control,
   record,
   getValues,
-}: HeadwordInterface): ReactElement => (
-  <Box className="flex flex-col w-full">
-    <Box className="flex justify-between items-between">
-      <FormHeader
-        title="Headword"
-        tooltip={`This is the headword that should ideally be in to Standard Igbo.
-        Add diacritic marks to denote the tone for the word. 
-        All necessary accented characters will appear in the letter popup`}
-      />
-      <Controller
-        render={({ onChange, value, ref }) => (
-          <Checkbox
-            onChange={(e) => onChange(e.target.checked)}
-            isChecked={value}
-            defaultIsChecked={record.isStandardIgbo}
-            ref={ref}
-            data-test="isStandardIgbo-checkbox"
-            size="lg"
-          >
-            <span className="font-bold">Is Standard Igbo</span>
-          </Checkbox>
-        )}
-        defaultValue={record.isStandardIgbo || getValues().isStandardIgbo}
-        name="isStandardIgbo"
-        control={control}
-      />
-    </Box>
-    <Controller
-      render={(props) => (
-        <Input
-          {...props}
-          className="form-input"
-          placeholder="i.e. biko, igwe, mmiri"
-          data-test="word-input"
+}: HeadwordInterface): ReactElement => {
+  const isAsCompleteAsPossible = (
+    record.word
+    && record.wordClass
+    && Array.isArray(record.definitions) && record.definitions.length
+    && Array.isArray(record.examples) && record.examples.length
+    && record.pronunciation
+    && record.isStandardIgbo
+  );
+
+  return (
+    <Box className="flex flex-col w-full">
+      <Box className="flex flex-col lg:flex-row my-4 lg:my-0 space-y-2 lg:space-y-0 justify-between items-between">
+        <FormHeader
+          title="Headword"
+          tooltip={`This is the headword that should ideally be in to Standard Igbo.
+          Add diacritic marks to denote the tone for the word. 
+          All necessary accented characters will appear in the letter popup`}
         />
+        <Box display="flex" alignItems="center" className="lg:space-x-3">
+          <Controller
+            render={({ onChange, value, ref }) => (
+              <Checkbox
+                onChange={(e) => onChange(e.target.checked)}
+                isChecked={value}
+                defaultIsChecked={record.isStandardIgbo}
+                ref={ref}
+                data-test="isStandardIgbo-checkbox"
+                size="lg"
+              >
+                <span className="font-bold">Is Standard Igbo</span>
+              </Checkbox>
+            )}
+            defaultValue={record.isStandardIgbo || getValues().isStandardIgbo}
+            name="isStandardIgbo"
+            control={control}
+          />
+          <Tooltip
+            label={!isAsCompleteAsPossible ? 'Unable to mark as complete until all necessary fields are filled' : ''}
+          >
+            <Box display="flex">
+              <Controller
+                render={({ onChange, value, ref }) => (
+                  <Checkbox
+                    onChange={(e) => onChange(e.target.checked)}
+                    isChecked={value}
+                    isDisabled={!isAsCompleteAsPossible}
+                    defaultIsChecked={record.isComplete}
+                    ref={ref}
+                    data-test="isComplete-checkbox"
+                    size="lg"
+                  >
+                    <span className="font-bold">Is Complete</span>
+                  </Checkbox>
+                )}
+                defaultValue={record.isComplete || getValues().isComplete}
+                name="isComplete"
+                control={control}
+              />
+            </Box>
+          </Tooltip>
+        </Box>
+      </Box>
+      <Controller
+        render={(props) => (
+          <Input
+            {...props}
+            className="form-input"
+            placeholder="i.e. biko, igwe, mmiri"
+            data-test="word-input"
+          />
+        )}
+        name="word"
+        control={control}
+        defaultValue={record.word || getValues().word}
+      />
+      {errors.word && (
+        <p className="error">Word is required</p>
       )}
-      name="word"
-      control={control}
-      defaultValue={record.word || getValues().word}
-    />
-    {errors.word && (
-      <p className="error">Word is required</p>
-    )}
-  </Box>
-);
+    </Box>
+  );
+};
 
 export default HeadwordForm;

--- a/src/shared/components/views/shows/WordShow.tsx
+++ b/src/shared/components/views/shows/WordShow.tsx
@@ -105,7 +105,7 @@ const WordShow = (props: ShowProps): ReactElement => {
                 </Heading>
                 <EditDocumentIds collection="words" originalId={originalWordId} id={id} title="Origin Word Id:" />
               </Box>
-              <CompleteWordPreview record={record} className="my-5 lg:my-0" />
+              <CompleteWordPreview record={record} showFull className="my-5 lg:my-0" />
             </Box>
             <Box className="flex flex-col lg:flex-row w-full justify-between">
               <Box>


### PR DESCRIPTION
## Background
Translators have been requesting to make it easier to keep track and mark when a word is complete. This PR introduces the new Is Complete checkbox that:
* Enables translators to mark words as complete if they follow our [Dictionary Editing Standards Doc](https://www.notion.so/Dictionary-Editing-Standards-6786e201c6ef4a1ca5f46fa9b1516552)

The checkbox will be clickable if the word meets all the word completion criteria **except** if the headword has accent marks. This means if a word meets all the criteria points but doesn't have accent marks for the headword then the editor will be able to click the Is Complete button

## Is Complete Checkbox
<img width="668" alt="Screen Shot 2021-12-18 at 4 01 53 PM" src="https://user-images.githubusercontent.com/16169291/146655522-d462f813-0408-4c2b-a33c-0ac8ce10ddea.png">
<img width="554" alt="Screen Shot 2021-12-18 at 4 01 44 PM" src="https://user-images.githubusercontent.com/16169291/146655523-dc87f47b-051e-4795-94af-49936b1820d8.png">

