### PR TITLE
Use fallback Firebase user

### DIFF
--- a/src/backend/controllers/exampleSuggestions.ts
+++ b/src/backend/controllers/exampleSuggestions.ts
@@ -183,7 +183,10 @@ export const removeExampleSuggestion = (id: string): Promise<Interfaces.ExampleS
       if (!exampleSuggestion) {
         throw new Error('No example suggestion exists with the provided id.');
       }
-      const { email: userEmail } = await findUser(exampleSuggestion.authorId) as Interfaces.FormattedUser;
+      const { email: userEmail } = (
+        (await findUser(exampleSuggestion.authorId) as Interfaces.FormattedUser)
+        || { email: '' }
+      );
       /* Sends rejection email to user if they provided an email and the exampleSuggestion isn't merged */
       if (userEmail && !exampleSuggestion.merged) {
         sendRejectedEmail({

--- a/src/backend/controllers/users.ts
+++ b/src/backend/controllers/users.ts
@@ -79,6 +79,7 @@ export const getUsers = async (req, res, next) => {
 };
 
 /* Looks into Firebase for user */
+// TODO: expand this function to look inside both Igbo API Editor Platform and Nkowaokwu Firebase projects
 export const findUser = async (uid: string): Promise<Interfaces.FormattedUser | string> => {
   if (process.env.NODE_ENV !== 'test') {
     const user = await admin.auth().getUser(uid);


### PR DESCRIPTION
## Background
If a suggestion comes in from Nkọwa okwu, and an editor wants to delete that suggestion then the Igbo API Editor Platform should use a fallback Firebase user object to avoid throwing a 500 error back to the client side