### PR TITLE
Update sender email to become authorized

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -50,6 +50,7 @@ jobs:
           firebase functions:config:set sendgrid.api_key=$SENDGRID_API_KEY sendgrid.merged_suggestion_template=$SENDGRID_MERGED_SUGGESTION_TEMPLATE --token $FIREBASE_TOKEN
           firebase functions:config:set sendgrid.rejected_suggestion_template=$SENDGRID_REJECTED_SUGGESTION_TEMPLATE sendgrid.merged_stats_template=$SENDGRID_MERGED_STATS_TEMPLATE sendgrid.suggestions_review_reminder_template=$SENDGRID_SUGGESTIONS_REVIEW_REMINDER_TEMPLATE --token $FIREBASE_TOKEN
           firebase functions:config:set sendgrid.new_user_notification_template=$SENDGRID_NEW_USER_NOTIFICATION_TEMPLATE --token $FIREBASE_TOKEN
+          firebase functions:config:set sendgrid.sender_email=$SENDGRID_SENDER_EMAIL --token $FIREBASE_TOKEN
           firebase functions:config:set aws.access_key=$AWS_ACCESS_KEY aws.secret_access_key=$AWS_SECRET_ACCESS_KEY aws.bucket=$AWS_BUCKET aws.region=$AWS_REGION
           yarn build
         env:
@@ -65,6 +66,7 @@ jobs:
           SENDGRID_MERGED_STATS_TEMPLATE: ${{ secrets.SENDGRID_MERGED_STATS_TEMPLATE }}
           SENDGRID_SUGGESTIONS_REVIEW_REMINDER_TEMPLATE: ${{ secrets.SENDGRID_SUGGESTIONS_REVIEW_REMINDER_TEMPLATE }}
           SENDGRID_NEW_USER_NOTIFICATION_TEMPLATE: ${{ secrets.SENDGRID_NEW_USER_NOTIFICATION_TEMPLATE }}
+          SENDGRID_SENDER_EMAIL: ${{ secrets.SENDGRID_SENDER_EMAIL }}
           AWS_ACCESS_KEY: ${{ secrets.AWS_ACCESS_KEY }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_BUCKET: ${{ secrets.AWS_BUCKET }}

--- a/src/backend/config.ts
+++ b/src/backend/config.ts
@@ -14,8 +14,8 @@ export const REJECTED_SUGGESTION_TEMPLATE = config?.sendgrid?.rejected_suggestio
 export const MERGED_STATS_TEMPLATE = config?.sendgrid?.merged_stats_template;
 export const SUGGESTIONS_REVIEW_REMINDER_TEMPLATE = config?.sendgrid?.suggestions_review_reminder_template;
 export const NEW_USER_NOTIFICATION_TEMPLATE = config?.sendgrid?.new_user_notification_template;
-export const API_FROM_EMAIL = process.env.API_FROM_EMAIL || 'igboapi@gmail.com';
-export const NKOWAOKWU_FROM_EMAIL = process.env.NKOWAOKWU_FROM_EMAIL || 'nkowaokwu@gmail.com';
+export const API_FROM_EMAIL = config?.sendgrid?.sender_email;
+export const NKOWAOKWU_FROM_EMAIL = config?.sendgrid?.sender_email;
 
 // AWS
 export const AWS_ACCESS_KEY = config?.aws?.access_key;

--- a/src/backend/controllers/email.ts
+++ b/src/backend/controllers/email.ts
@@ -30,13 +30,11 @@ const constructMessage = (messageFields: Interfaces.EmailMessage): Interfaces.Co
 export const sendEmail = (message: Interfaces.ConstructedMessage): Promise<void> => (
   process.env.NODE_ENV !== 'test' ? sgMail.send(message)
     .then(() => {
-      if (process.env.NODE_ENV !== 'production') {
-        console.log('Email successfully sent.');
-      }
+      console.log('Email successfully sent.');
     })
     .catch((err) => {
+      console.trace('sendEmail error:', err.response.body);
       if (process.env.NODE_ENV !== 'production') {
-        console.log(err.response.body);
         return Promise.resolve(err.response.body);
       }
       throw err;


### PR DESCRIPTION
## Background
All emails stopped sent since December.

## Solution
Our SendGrid account expected a certain email to be our Authorized Sender. This PR places that authorized email inside GitHub Secrets and injects the email via Firebase Function variables so it can be used to send authorized emails.