### PR TITLE
Support mp3 file extension

### DIFF
--- a/src/backend/controllers/utils/AWS-API.ts
+++ b/src/backend/controllers/utils/AWS-API.ts
@@ -52,40 +52,43 @@ export const createAudioPronunciation = async (id: string, pronunciationData: st
 };
 
 /* Deletes a .webm object in the AWS S3 Bucket */
-export const deleteAudioPronunciation = async (id): Promise<any> => {
+export const deleteAudioPronunciation = async (id: string, isMp3 = false): Promise<any> => {
   if (!id) {
     throw new Error('No pronunciation id provided');
   }
   if (isCypress || !isProduction) {
     return `${dummyUriPath}${id}`;
   }
+  const extension = isMp3 ? 'mp3' : 'webm';
   const params = {
     ...baseParams,
-    Key: `${pronunciationPath}/${id}.webm`,
+    Key: `${pronunciationPath}/${id}.${extension}`,
   };
 
   return s3.deleteObject(params).promise();
 };
 /* Takes an old and new pronunciation id and copies it (copies) */
-export const copyAudioPronunciation = async (oldDocId: string, newDocId: string): Promise<any> => {
+export const copyAudioPronunciation = async (oldDocId: string, newDocId: string, isMp3 = false): Promise<any> => {
   if (isCypress || !isProduction) {
     return `${dummyUriPath}${newDocId}`;
   }
 
+  const extension = isMp3 ? 'mp3' : 'webm';
+
   const copyParams = {
     ...baseParams,
-    Key: `${pronunciationPath}/${newDocId}.webm`,
+    Key: `${pronunciationPath}/${newDocId}.${extension}`,
     ACL: 'public-read',
-    CopySource: `${bucket}/${pronunciationPath}/${oldDocId}.webm`,
+    CopySource: `${bucket}/${pronunciationPath}/${oldDocId}.${extension}`,
   };
 
   await s3.copyObject(copyParams).promise();
-  const copiedAudioPronunciationUri = `${uriPath}/${newDocId}.webm`;
+  const copiedAudioPronunciationUri = `${uriPath}/${newDocId}.${extension}`;
   return copiedAudioPronunciationUri;
 };
 
 /* Takes an old and new pronunciation id and renames it (copies and deletes) */
-export const renameAudioPronunciation = async (oldDocId: string, newDocId: string): Promise<any> => {
+export const renameAudioPronunciation = async (oldDocId: string, newDocId: string, isMp3 = false): Promise<any> => {
   if (isCypress || !isProduction) {
     if (!oldDocId) {
       return '';
@@ -102,7 +105,7 @@ export const renameAudioPronunciation = async (oldDocId: string, newDocId: strin
     return '';
   }
 
-  const renamedAudioPronunciationUri = await copyAudioPronunciation(oldDocId, newDocId);
+  const renamedAudioPronunciationUri = await copyAudioPronunciation(oldDocId, newDocId, isMp3);
   await deleteAudioPronunciation(oldDocId);
 
   return renamedAudioPronunciationUri;

--- a/src/backend/controllers/wordSuggestions.ts
+++ b/src/backend/controllers/wordSuggestions.ts
@@ -198,10 +198,12 @@ export const deleteWordSuggestion = (
           throw new Error('No word suggestion exists with the provided id.');
         }
         /* Deletes all word pronunciations for the headword and dialects */
-        await deleteAudioPronunciation(id);
-        await Promise.all(Object.values(wordSuggestion.dialects).map(async ({ dialect }) => (
-          deleteAudioPronunciation(`${id}-${dialect}`)
-        )));
+        const isPronunciationMp3 = wordSuggestion.pronunciation && wordSuggestion.pronunciation.includes('mp3');
+        await deleteAudioPronunciation(id, isPronunciationMp3);
+        await Promise.all(Object.values(wordSuggestion.dialects).map(async ({ dialect, pronunciation }) => {
+          const dialectPronunciationMp3 = pronunciation && pronunciation.includes('mp3');
+          deleteAudioPronunciation(`${id}-${dialect}`, dialectPronunciationMp3);
+        }));
         const { email: userEmail } = await findUser(wordSuggestion.authorId) as Interfaces.FormattedUser;
         /* Sends rejection email to user if they provided an email and the wordSuggestion isn't merged */
         if (userEmail && !wordSuggestion.merged) {

--- a/src/backend/models/plugins/pronunciationHooks.ts
+++ b/src/backend/models/plugins/pronunciationHooks.ts
@@ -29,13 +29,14 @@ export const uploadPronunciation = (schema: mongoose.Schema<Interfaces.WordSugge
       } else if (this.pronunciation.startsWith('https://') && !this.pronunciation.includes(`${id}.`)) {
         // If the pronunciation data for the headword is a uri, we will duplicate the uri
         // so that the new uri will only be associated with the suggestion
+        const isMp3 = this.pronunciation.includes('mp3');
         const oldId: string = last(compact(this.pronunciation.split(/.mp3|.webm/).join('').split('/')));
         const newId: string = id;
 
         /* If we are saving a new word suggestion, then we want to copy all the original audio files */
         this.pronunciation = await (this.isNew
-          ? copyAudioPronunciation(oldId, newId)
-          : renameAudioPronunciation(oldId, newId));
+          ? copyAudioPronunciation(oldId, newId, isMp3)
+          : renameAudioPronunciation(oldId, newId, isMp3));
       }
       /**
        * Steps through each dialect and checks to see if it has audio data to be saved in AWS
@@ -57,13 +58,14 @@ export const uploadPronunciation = (schema: mongoose.Schema<Interfaces.WordSugge
         } else if (pronunciation.startsWith('https://') && !pronunciation.includes(`${id}-${dialect}`)) {
           // If the pronunciation data in the current dialect is a uri, we will duplicate the uri
           // so that the new uri will only be associated with the suggestion
+          const isMp3 = pronunciation.includes('mp3');
           const oldId: string = last(compact(pronunciation.split(/.mp3|.webm/).join('').split('/')));
           const newId = `${id}-${dialect}`;
 
           /* If we are saving a new word suggestion, then we want to copy all the original audio files */
           this.dialects[dialect].pronunciation = await (this.isNew
-            ? copyAudioPronunciation(oldId, newId)
-            : renameAudioPronunciation(oldId, newId));
+            ? copyAudioPronunciation(oldId, newId, isMp3)
+            : renameAudioPronunciation(oldId, newId, isMp3));
         }
       }));
     }


### PR DESCRIPTION
## Background
Certain words were unable to be saved. Editors would see the error “this specified key does not exist”

## Solution
The AWS audio files include file extensions. The default and platform-preferred audio file extension is `.webm`. However, the S3 bucket includes `.mp3` files that came from our project's old Google Drive of audio recordings back when editors were recording audio on their mobile devices and uploading rather than recording from within the Editor Platform.

This PR checks to see if the incoming audio URI is an `.mp3` or not. If it is, then we will look for the audio file with the `.mp3` file extension

## Future Considerations
Since we don't need to include file extensions for S3 to know that it's an audio file, it would be worth considering making a change where we handle audio files where we don't include file extensions in file names.

## Associated Bug Report
https://www.notion.so/Bug-Report-Word-Editing-Nsibidi-426b197c334742dc80f180dfb649a0f2