### PR TITLE
Place the nsibidi input beneath the headword to fit on different screen sizes

### DIFF
--- a/src/shared/components/views/components/WordEditForm/WordEditForm.tsx
+++ b/src/shared/components/views/components/WordEditForm/WordEditForm.tsx
@@ -251,19 +251,17 @@ const WordEditForm = ({
       <Box className="w-full">
         <Box className="flex flex-col lg:flex-row space-x-0 lg:space-x-4">
           <Box className="flex flex-col w-full lg:w-1/2">
-            <Box className="flex flex-row space-x-3 w-full">
-              <HeadwordForm
-                errors={errors}
-                control={control}
-                record={record}
-                getValues={getValues}
-              />
-              <NsibidiForm
-                control={control}
-                record={record}
-                getValues={getValues}
-              />
-            </Box>
+            <HeadwordForm
+              errors={errors}
+              control={control}
+              record={record}
+              getValues={getValues}
+            />
+            <NsibidiForm
+              control={control}
+              record={record}
+              getValues={getValues}
+            />
             <PartOfSpeechForm
               errors={errors}
               control={control}


### PR DESCRIPTION
## Background
The Nsịbịdị input field was getting squished sitting between the headword and word pronunciation input fields

## After
![Screen Shot 2022-01-15 at 7 33 49 PM](https://user-images.githubusercontent.com/16169291/149642705-4b440802-0a28-4a5f-ac62-e4aeb08f690c.png)

## Before
![Screen Shot 2022-01-15 at 7 34 02 PM](https://user-images.githubusercontent.com/16169291/149642707-eaf303ab-dbf4-436c-bcbf-7f77d8f4aa5d.png)

