### PR TITLE
Support linking stems with word documents

### DIFF
--- a/src/shared/components/ArrayPreview.tsx
+++ b/src/shared/components/ArrayPreview.tsx
@@ -1,20 +1,27 @@
 import React, { ReactElement } from 'react';
 import { truncate } from 'lodash';
 import { ArrayPreviewProps } from '../interfaces';
+import ResolvedWord from './ResolvedWord';
 
 /* Builds the list of preview items */
-const populateList = (items = []) => {
+const populateList = (items = [], source) => {
   if (!items?.length) {
     return [];
   }
   const itemsPreview = items.slice(0, 10).map((item) => (
-    <li className="list-disc" key={item}>{truncate(item, { length: 120 })}</li>
+    <li className="list-disc" key={item}>
+      {source === 'stems' ? (
+        <ResolvedWord wordId={item} />
+      ) : (
+        truncate(item, { length: 120 })
+      )}
+    </li>
   ));
 
   if (items.length > itemsPreview.length) {
     itemsPreview.push((
       <li className="font-bold">
-        {`${items.length - itemsPreview.length} more definitions`}
+        {`${items.length - itemsPreview.length} more ${source}`}
       </li>
     ));
   }
@@ -23,7 +30,7 @@ const populateList = (items = []) => {
 
 /* Final list of preview items */
 const ArrayPreview = ({ source, record = {} }: ArrayPreviewProps): ReactElement => (
-  <ul data-test={`${source}-preview`}>{populateList(record && record[source])}</ul>
+  <ul data-test={`${source}-preview`}>{populateList(record && record[source], source)}</ul>
 );
 
 export default ArrayPreview;

--- a/src/shared/components/ResolvedWord.tsx
+++ b/src/shared/components/ResolvedWord.tsx
@@ -1,0 +1,39 @@
+import React, { useEffect, useState, ReactElement } from 'react';
+import { Box, Spinner, Tooltip } from '@chakra-ui/react';
+import { InfoOutlineIcon } from '@chakra-ui/icons';
+import network from '../../Core/Dashboard/network';
+
+const ResolvedWord = ({ wordId }: { wordId: string }): ReactElement => {
+  const [resolvedWord, setResolvedWord] = useState(null);
+  const [isLinked, setIsLinked] = useState(true);
+
+  useEffect(() => {
+    (async () => {
+      const word = await network({ url: `/words/${wordId}` })
+        .then(({ json: word }) => word)
+        .catch(() => {
+          setIsLinked(false);
+          return { word: wordId };
+        });
+      setResolvedWord(word);
+    })();
+  }, []);
+
+  return resolvedWord ? (
+    isLinked ? (
+      <a className="text-blue-400 underline" href={`#/words/${wordId}/show`}>{resolvedWord.word}</a>
+    ) : (
+      <Box display="flex" alignItems="center" className="space-x-2">
+        <p>{resolvedWord.word}</p>
+        <Tooltip
+          label={`This word metadata is not linked. To properly link this 
+          metadata to the word, edit this word and link this metadata.`}
+        >
+          <InfoOutlineIcon color="orange.600" width="4" className="ml-2" />
+        </Tooltip>
+      </Box>
+    )
+  ) : <Spinner />;
+};
+
+export default ResolvedWord;

--- a/src/shared/components/views/components/WordEditForm/WordEditForm.tsx
+++ b/src/shared/components/views/components/WordEditForm/WordEditForm.tsx
@@ -305,9 +305,12 @@ const WordEditForm = ({
               control={control}
             />
             <StemsForm
+              errors={errors}
               stems={stems}
               setStems={setStems}
               control={control}
+              setValue={setValue}
+              record={record}
             />
             <SynonymsForm
               errors={errors}

--- a/src/shared/components/views/components/WordEditForm/components/AntonymsForm/AntonymsForm.tsx
+++ b/src/shared/components/views/components/WordEditForm/components/AntonymsForm/AntonymsForm.tsx
@@ -104,7 +104,7 @@ const AntonymsForm = ({
     } catch (err) {
       toast({
         title: 'Unable to add antonym',
-        description: 'You have provided an either an word id or a the current word\'s or parent word\'s id.',
+        description: 'You have provided an either an invalid word id or a the current word\'s or parent word\'s id.',
         status: 'warning',
         duration: 4000,
         isClosable: true,
@@ -122,13 +122,11 @@ const AntonymsForm = ({
         defaultValue=""
       />
       <Box className="flex items-center my-5 w-full justify-between">
-        <Box className="flex flex-col">
-          <FormHeader
-            title="Antonyms"
-            tooltip={`Antonyms of the current word using Standard Igbo. 
-            You can search for a word or paste in the word id.`}
-          />
-        </Box>
+        <FormHeader
+          title="Antonyms"
+          tooltip={`Antonyms of the current word using Standard Igbo. 
+          You can search for a word or paste in the word id.`}
+        />
       </Box>
       <Box className="flex flex-row mb-4 space-x-2">
         <Input

--- a/src/shared/components/views/components/WordEditForm/components/ExamplesForm/ExamplesForm.tsx
+++ b/src/shared/components/views/components/WordEditForm/components/ExamplesForm/ExamplesForm.tsx
@@ -51,7 +51,7 @@ const ExamplesForm = ({
             }, index) => {
               const formData = getValues();
               return (
-                <Box className="list-container" key={`${igbo}-${english}`}>
+                <Box className="list-container" key={`${id}-${igbo}-${english}`}>
                   <Box
                     data-example-id={id}
                     data-original-example-id={originalExampleId}

--- a/src/shared/components/views/components/WordEditForm/components/HeadwordForm/HeadwordForm.tsx
+++ b/src/shared/components/views/components/WordEditForm/components/HeadwordForm/HeadwordForm.tsx
@@ -29,7 +29,11 @@ const HeadwordForm = ({
           Add diacritic marks to denote the tone for the word. 
           All necessary accented characters will appear in the letter popup`}
         />
-        <Box display="flex" alignItems="center" className="lg:space-x-3">
+        <Box
+          display="flex"
+          flexDirection="column"
+          alignItems="flex-start"
+        >
           <Controller
             render={({ onChange, value, ref }) => (
               <Checkbox

--- a/src/shared/components/views/components/WordEditForm/components/StemsForm/StemsForm.tsx
+++ b/src/shared/components/views/components/WordEditForm/components/StemsForm/StemsForm.tsx
@@ -1,63 +1,183 @@
-import React, { ReactElement } from 'react';
-import { Box, Button } from '@chakra-ui/react';
-import { AddIcon, DeleteIcon } from '@chakra-ui/icons';
+import React, { useEffect, useState, ReactElement } from 'react';
+import {
+  Box,
+  IconButton,
+  Spinner,
+  Tooltip,
+  useToast,
+} from '@chakra-ui/react';
+import { AddIcon } from '@chakra-ui/icons';
+import { compact } from 'lodash';
 import { Controller } from 'react-hook-form';
 import FormHeader from '../../../FormHeader';
-import { Input } from '../../../../../../primitives';
+import { Input, WordPill } from '../../../../../../primitives';
+import network from '../../../../../../../Core/Dashboard/network';
 import StemsFormInterface from './StemsFormInterface';
 
-const StemsForm = ({ stems, setStems, control }: StemsFormInterface): ReactElement => (
-  <Box className="w-full bg-gray-200 rounded-lg p-2 mb-2">
-    <Box className="flex items-center my-5 w-full justify-between">
-      <Box className="flex flex-col">
+const Stems = (
+  { stemIds, updateStems }
+  : { stemIds: string[], updateStems: (value: string[]) => void },
+) => {
+  const [resolvedStems, setResolvedStems] = useState(null);
+  const [isLoadingStems, setIsLoadingStems] = useState(false);
+  useEffect(() => {
+    (async () => {
+      setIsLoadingStems(true);
+      try {
+        /**
+         * We compact the resolved stems so that if a word cannot be found
+         * by its MongoDB Id or regular word search, the compact array will be used
+         * to save the Word Suggestion, omitting the unwanted word.
+         */
+        const compactedResolvedStems = compact(await Promise.all(stemIds.map(async (stemId) => {
+          const word = await network({ url: `/words/${stemId}` })
+            .then(({ json: word }) => word)
+            .catch(async () => {
+              /**
+               * If there is a regular word string (not a MongoDB Id) then the platform
+               * will search the Igbo API and find the matching word and insert
+               * that word's id
+               */
+
+              const { json: wordsResults } = await network({ url: `/words?keyword=${stemId}` });
+              const fallbackWord = wordsResults.find(({ word }) => word.normalize('NFD') === stemId.normalize('NFD'));
+              return fallbackWord;
+            });
+          return word;
+        })));
+        setResolvedStems(compactedResolvedStems);
+        if (!(resolvedStems && resolvedStems.every(({ id }, index) => stemIds[index] === id))) {
+          updateStems(compactedResolvedStems.map(({ id }) => id));
+        }
+      } finally {
+        setIsLoadingStems(false);
+      }
+    })();
+  }, [stemIds]);
+
+  return isLoadingStems ? (
+    <Spinner />
+  ) : resolvedStems && resolvedStems.length ? (
+    <Box display="flex" flexDirection="column" className="space-y-3">
+      {resolvedStems.map((word, index) => (
+        <Box
+          key={word.id}
+          display="flex"
+          flexDirection="row"
+          justifyContent="space-between"
+          alignItems="center"
+          borderColor="blue.400"
+          borderWidth="1px"
+          backgroundColor="blue.50"
+          borderRadius="full"
+          minWidth="36"
+          py={2}
+          px={6}
+        >
+          <WordPill
+            {...word}
+            index={index}
+            onDelete={() => {
+              const filteredStems = [...stemIds];
+              filteredStems.splice(index, 1);
+              updateStems(filteredStems);
+            }}
+          />
+        </Box>
+      ))}
+    </Box>
+  ) : (
+    <Box className="flex w-full justify-center">
+      <p className="text-gray-600">No synonyms</p>
+    </Box>
+  );
+};
+
+const StemsForm = ({
+  errors,
+  stems,
+  setStems,
+  control,
+  setValue,
+  record,
+} : StemsFormInterface): ReactElement => {
+  const [input, setInput] = useState('');
+  const toast = useToast();
+
+  const updateStems = (value) => {
+    setStems(value);
+    setValue('stems', value);
+  };
+
+  const canAddStem = (userInput) => (
+    !stems.includes(userInput)
+    && userInput !== record.id
+    && userInput !== record.originalWordId
+  );
+
+  const handleAddStem = async (userInput = input) => {
+    try {
+      if (canAddStem(userInput)) {
+        const word = await network({ url: `/words/${userInput}` }).then(({ json: word }) => word);
+        updateStems([...stems, word.id]);
+      } else {
+        throw new Error('Invalid word id');
+      }
+    } catch (err) {
+      toast({
+        title: 'Unable to add synonym',
+        description: 'You have provided an either an invalid word id or a the current word\'s or parent word\'s id.',
+        status: 'warning',
+        duration: 4000,
+        isClosable: true,
+      });
+    } finally {
+      setInput('');
+    }
+  };
+  return (
+    <Box className="w-full bg-gray-200 rounded-lg p-2 mb-2">
+      <Controller
+        render={(props) => <input style={{ position: 'absolute', visibility: 'hidden' }} {...props} />}
+        name="stems"
+        control={control}
+        defaultValue=""
+      />
+      <Box className="flex items-center my-5 w-full justify-between">
         <FormHeader
           title="Word Stems"
           tooltip={`Root or stem Igbo words when combined with other stems create new words.
-           Please add tone markings.`}
+          Please add tone markings.`}
         />
       </Box>
-      <Button
-        colorScheme="green"
-        aria-label="Add Stem"
-        minWidth="130px"
-        onClick={() => setStems([...stems, ''])}
-        leftIcon={<AddIcon />}
-      >
-        Add Stem
-      </Button>
+      <Box className="flex flex-row mb-4 space-x-2">
+        <Input
+          value={input}
+          searchApi
+          data-test="stem-search"
+          placeholder="Search for stem or use word id"
+          onChange={(e) => setInput(e.target.value)}
+          onSelect={(e) => handleAddStem(e.id)}
+          className="form-input"
+        />
+        <Tooltip label="Click this button to add the stem">
+          <IconButton
+            colorScheme="green"
+            aria-label="Add stem"
+            onClick={() => handleAddStem()}
+            icon={<AddIcon />}
+          />
+        </Tooltip>
+      </Box>
+      <Stems
+        stemIds={stems}
+        updateStems={updateStems}
+      />
+      {errors.stems && (
+        <p className="error">{errors.stems.message || errors.stems[0]?.message}</p>
+      )}
     </Box>
-    {stems.length ? stems.map((stem, index) => (
-      <Box className="list-container" key={stem}>
-        <Controller
-          render={(props) => (
-            <Input
-              {...props}
-              className="form-input"
-            />
-          )}
-          name={`stems[${index}]`}
-          control={control}
-          defaultValue={stems[index]}
-        />
-        <Button
-          colorScheme="red"
-          aria-label="Delete Stem"
-          onClick={() => {
-            const filteredStems = [...stems];
-            filteredStems.splice(index, 1);
-            setStems(filteredStems);
-          }}
-          className="ml-3"
-          leftIcon={<DeleteIcon />}
-        >
-          Delete
-        </Button>
-      </Box>
-    )) : (
-      <Box className="flex w-full justify-center">
-        <p className="text-gray-600">No stems</p>
-      </Box>
-    )}
-  </Box>
-);
+  );
+};
+
 export default StemsForm;

--- a/src/shared/components/views/components/WordEditForm/components/StemsForm/StemsFormInterface.ts
+++ b/src/shared/components/views/components/WordEditForm/components/StemsForm/StemsFormInterface.ts
@@ -1,9 +1,14 @@
+import { Record } from 'react-admin';
 import { Control } from 'react-hook-form';
+import { Word } from '../../../../../../../backend/controllers/utils/interfaces';
 
 interface StemsForm {
+  errors: any,
   stems: string[],
   setStems: (array: string[]) => void,
   control: Control,
+  setValue: (key: string, value: any) => void,
+  record: Record | Word,
 };
 
 export default StemsForm;

--- a/src/shared/components/views/components/WordEditForm/components/SynonymsForm/SynonymsForm.tsx
+++ b/src/shared/components/views/components/WordEditForm/components/SynonymsForm/SynonymsForm.tsx
@@ -104,7 +104,7 @@ const SynonymsForm = ({
     } catch (err) {
       toast({
         title: 'Unable to add synonym',
-        description: 'You have provided an either an word id or a the current word\'s or parent word\'s id.',
+        description: 'You have provided an either an invalid word id or a the current word\'s or parent word\'s id.',
         status: 'warning',
         duration: 4000,
         isClosable: true,
@@ -122,13 +122,11 @@ const SynonymsForm = ({
         defaultValue=""
       />
       <Box className="flex items-center my-5 w-full justify-between">
-        <Box className="flex flex-col">
-          <FormHeader
-            title="Synonyms"
-            tooltip={`Synonyms of the current word using Standard Igbo. 
-            You can search for a word or paste in the word id.`}
-          />
-        </Box>
+        <FormHeader
+          title="Synonyms"
+          tooltip={`Synonyms of the current word using Standard Igbo. 
+          You can search for a word or paste in the word id.`}
+        />
       </Box>
       <Box className="flex flex-row mb-4 space-x-2">
         <Input

--- a/src/shared/components/views/shows/WordShow.tsx
+++ b/src/shared/components/views/shows/WordShow.tsx
@@ -21,6 +21,7 @@ import ArrayDiffField from './diffFields/ArrayDiffField';
 import ExampleDiff from './diffFields/ExampleDiff';
 import ArrayDiff from './diffFields/ArrayDiff';
 import CompleteWordPreview from '../../CompleteWordPreview';
+import ResolvedWord from '../../ResolvedWord';
 
 const DIFF_FILTER_KEYS = [
   'id',
@@ -109,15 +110,17 @@ const WordShow = (props: ShowProps): ReactElement => {
               <CompleteWordPreview record={record} showFull className="my-5 lg:my-0" />
             </Box>
             <Box className="flex flex-col lg:flex-row w-full justify-between">
-              <Box>
-                <Heading fontSize="lg" className="text-xl text-gray-600">Is Standard Igbo</Heading>
-                <DiffField
-                  path="isStandardIgbo"
-                  diffRecord={diffRecord}
-                  fallbackValue={isStandardIgbo}
-                  renderNestedObject={(value) => <span>{String(value)}</span>}
-                />
-                <Box className="flex flex-row">
+              <Box className="space-y-3">
+                <Box className="flex flex-col">
+                  <Heading fontSize="lg" className="text-xl text-gray-600">Is Standard Igbo</Heading>
+                  <DiffField
+                    path="isStandardIgbo"
+                    diffRecord={diffRecord}
+                    fallbackValue={isStandardIgbo}
+                    renderNestedObject={(value) => <span>{String(value)}</span>}
+                  />
+                </Box>
+                <Box className="flex flex-col">
                   <Heading fontSize="lg" className="text-xl text-gray-600">Word</Heading>
                   <DiffField
                     path="word"
@@ -125,14 +128,14 @@ const WordShow = (props: ShowProps): ReactElement => {
                     fallbackValue={word}
                   />
                 </Box>
-                <Box className="flex flex-col mt-5 space-x-4">
+                <Box className="flex flex-col mt-5">
                   <Heading fontSize="lg" className="text-xl text-gray-600">Nsịbịdị</Heading>
                   <DiffField
                     path="nsibidi"
                     diffRecord={diffRecord}
                     fallbackValue={nsibidi}
                     renderNestedObject={(value) => (
-                      <span className="akagu">{value}</span>
+                      <span className={value ? 'akagu' : ''}>{value || 'N/A'}</span>
                     )}
                   />
                 </Box>
@@ -205,7 +208,11 @@ const WordShow = (props: ShowProps): ReactElement => {
                     originalWordRecord={originalWordRecord}
                   >
                     {/* @ts-ignore */}
-                    <ArrayDiff diffRecord={diffRecord} recordField="stems" />
+                    <ArrayDiff
+                      diffRecord={diffRecord}
+                      recordField="stems"
+                      renderNestedObject={(wordId) => <ResolvedWord wordId={wordId} />}
+                    />
                   </ArrayDiffField>
                 </Box>
                 <Box className="flex flex-col mt-5">
@@ -222,9 +229,7 @@ const WordShow = (props: ShowProps): ReactElement => {
                     <ArrayDiff
                       diffRecord={diffRecord}
                       recordField="synonyms"
-                      renderNestedObject={(wordId) => (
-                        <a className="text-blue-400 underline" href={`#/words/${wordId}/show`}>{wordId}</a>
-                      )}
+                      renderNestedObject={(wordId) => <ResolvedWord wordId={wordId} />}
                     />
                   </ArrayDiffField>
                 </Box>
@@ -242,9 +247,7 @@ const WordShow = (props: ShowProps): ReactElement => {
                     <ArrayDiff
                       diffRecord={diffRecord}
                       recordField="antonyms"
-                      renderNestedObject={(wordId) => (
-                        <a className="text-blue-400 underline" href={`#/words/${wordId}/show`}>{wordId}</a>
-                      )}
+                      renderNestedObject={(wordId) => <ResolvedWord wordId={wordId} />}
                     />
                   </ArrayDiffField>
                 </Box>

--- a/src/shared/primitives/DiacriticsBankPopup/DiacriticsBank.tsx
+++ b/src/shared/primitives/DiacriticsBankPopup/DiacriticsBank.tsx
@@ -23,7 +23,12 @@ const DiacriticsBank = (
         {diacritics.map((diacritic) => {
           const diacriticString = String.fromCharCode(diacritic);
           return (
-            <Button onClick={() => insertLetter(inputRef, diacriticString)}>{diacriticString}</Button>
+            <Button
+              key={`diacritic-key-${diacriticString}`}
+              onClick={() => insertLetter(inputRef, diacriticString)}
+            >
+              {diacriticString}
+            </Button>
           );
         })}
       </Box>

--- a/src/shared/primitives/Input.tsx
+++ b/src/shared/primitives/Input.tsx
@@ -120,7 +120,7 @@ const Input = React.forwardRef(({
           ) : (
             autoCompleteWords.map((word, index) => (
               <Box
-                key={word}
+                key={word.id}
                 py={3}
                 px={2}
                 _hover={{ backgroundColor: 'selected' }}


### PR DESCRIPTION
## Background
The Igbo API Editor Platform will now support linking stems to existing word documents to further link words and their metadata to other documents.

## Handling New Stems
When an editor searches for a stem, the search results will come from the Igbo API. If the desired stem word doesn't appear in the search, then that word needs to be added to the Igbo API so it can be linked to the current document.

## Handle Existing Stems
So far, stems have been plain strings that were placed within the word and word suggestion document. Now that the platform plans to handle only word document Ids to later resolve to get their full data, the platform will use fallback logic to search the string stem word to find it in the Igbo API. If the stem word exists, it's id will replace it's plain string text. If it doesn't, the stem word will be removed from the word suggestion document upon saving.

## Linking Stems
<img width="420" alt="Screen Shot 2022-01-20 at 7 00 37 PM" src="https://user-images.githubusercontent.com/16169291/150441341-052629d6-35ed-4ec5-b0d8-b9ce1fea474c.png">
