### PR TITLE
Hotfix dialects restructure

### DIFF
--- a/src/shared/components/views/components/WordEditForm/WordEditForm.tsx
+++ b/src/shared/components/views/components/WordEditForm/WordEditForm.tsx
@@ -74,7 +74,7 @@ const WordEditForm = ({
   const [synonyms, setSynonyms] = useState(record.synonyms || []);
   const [antonyms, setAntonyms] = useState(record.antonyms || []);
   const [isSubmitting, setIsSubmitting] = useState(false);
-  const [dialects, setDialects] = useState(Object.entries(record.dialects).map(([word, value]) => (
+  const [dialects, setDialects] = useState(Object.entries(record.dialects || {}).map(([word, value]) => (
     { ...value, word }
   )));
   const notify = useNotify();
@@ -108,7 +108,7 @@ const WordEditForm = ({
 
   /* Prepares dialects to include all required keys (dialectal word) for Mongoose schema validation */
   const prepareDialects = (): { dialects: { [key: string]: WordDialect } } => {
-    const formDialects = getValues().dialects;
+    const formDialects = getValues().dialects || {};
     return (
       dialects.reduce((finalDialects, dialect) => (
         /* The pronunciation, variations, and dialect are required for Mongoose schema validation */
@@ -134,7 +134,7 @@ const WordEditForm = ({
 
   /* Prepares the data to be cached */
   const createCacheWordData = (data, record: Record | Word = { id: null, dialects: {} }) => {
-    const dialects = prepareDialects();
+    const dialects = prepareDialects() || {};
     const cleanedData = {
       ...record,
       ...data,

--- a/src/shared/components/views/shows/diffFields/DialectDiff.tsx
+++ b/src/shared/components/views/shows/diffFields/DialectDiff.tsx
@@ -18,9 +18,10 @@ import * as Interfaces from '../../../../../backend/controllers/utils/interfaces
 
 /* Renders the visual red/green diff sections in the Show view */
 const DialectDiff = (
-  { record, diffRecord, resource }:
+  { record: propRecord, diffRecord, resource }:
   { record: Record, diffRecord: any, resource: string },
 ): ReactElement => {
+  const record = { ...(propRecord || {}), dialects: propRecord?.dialects || {} };
   const updatedDialects = [];
   // TODO: update this!!
   // diffRecord?.forEach(({ path = [] }) => {
@@ -32,7 +33,8 @@ const DialectDiff = (
   //     });
   // });
 
-  return record.word ? (
+  // @ts-ignore
+  return record?.word ? (
     <Box className="w-full">
       {updatedDialects.length ? updatedDialects.map(({ value, label }) => (
         <>


### PR DESCRIPTION
## Background
WordSuggestions could come back with no `dialects` field from the backend even if the `dialects` field would have a value of an empty object. This PR safe guards the `DialectsDiff` component that was originally always assuming that the `dialects` field is present. With the new dialects restructure, the `dialects` field was appearing as `undefined` which would crash the entire Word show view.