### PR TITLE
Support sending deletion requests to project admins

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -51,6 +51,7 @@ jobs:
           firebase functions:config:set sendgrid.rejected_suggestion_template=$SENDGRID_REJECTED_SUGGESTION_TEMPLATE sendgrid.merged_stats_template=$SENDGRID_MERGED_STATS_TEMPLATE sendgrid.suggestions_review_reminder_template=$SENDGRID_SUGGESTIONS_REVIEW_REMINDER_TEMPLATE --token $FIREBASE_TOKEN
           firebase functions:config:set sendgrid.new_user_notification_template=$SENDGRID_NEW_USER_NOTIFICATION_TEMPLATE --token $FIREBASE_TOKEN
           firebase functions:config:set sendgrid.updated_role_notification=$SENDGRID_UPDATED_ROLE_NOTIFICATION --token $FIREBASE_TOKEN
+          firebase functions:config:set sendgrid.document_deletion_request_notification=$SENDGRID_DOCUMENT_DELETION_REQUEST_NOTIFICATION --token $FIREBASE_TOKEN
           firebase functions:config:set sendgrid.sender_email=$SENDGRID_SENDER_EMAIL --token $FIREBASE_TOKEN
           firebase functions:config:set aws.access_key=$AWS_ACCESS_KEY aws.secret_access_key=$AWS_SECRET_ACCESS_KEY aws.bucket=$AWS_BUCKET aws.region=$AWS_REGION
           yarn build
@@ -68,6 +69,7 @@ jobs:
           SENDGRID_SUGGESTIONS_REVIEW_REMINDER_TEMPLATE: ${{ secrets.SENDGRID_SUGGESTIONS_REVIEW_REMINDER_TEMPLATE }}
           SENDGRID_NEW_USER_NOTIFICATION_TEMPLATE: ${{ secrets.SENDGRID_NEW_USER_NOTIFICATION_TEMPLATE }}
           SENDGRID_UPDATED_ROLE_NOTIFICATION: ${{ secrets.SENDGRID_UPDATED_ROLE_NOTIFICATION }}
+          SENDGRID_DOCUMENT_DELETION_REQUEST_NOTIFICATION: ${{ secrets.SENDGRID_DOCUMENT_DELETION_REQUEST_NOTIFICATION }}
           SENDGRID_SENDER_EMAIL: ${{ secrets.SENDGRID_SENDER_EMAIL }}
           AWS_ACCESS_KEY: ${{ secrets.AWS_ACCESS_KEY }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/cypress/constants/index.js
+++ b/cypress/constants/index.js
@@ -91,6 +91,7 @@ export const DocumentSelectOptions = {
   VIEW: 'View',
   SUGGEST_NEW_EDIT: 'Suggest New Edit',
   COMBINE_WORD_INTO: 'Combine Word Into...',
+  REQUEST_DELETE: /(Request to Delete Word)|(Request to Delete Example)/,
 };
 
 export const SuggestionSelectOptions = {

--- a/index.tsx
+++ b/index.tsx
@@ -15,6 +15,7 @@ import testRouter from './src/backend/routers/testRouter';
 import errorHandler from './src/backend/middleware/errorHandler';
 import afterRes from './src/backend/middleware/afterRes';
 import { onCreateUserAccount, onAssignUserToEditingGroup, onUpdatePermissions } from './src/backend/functions/users';
+import { onRequestDeleteDocument } from './src/backend/functions/documents';
 import {
   TEST_MONGO_URI,
   LOCAL_MONGO_URI,
@@ -90,6 +91,7 @@ server.use(errorHandler);
 export const createUserAccount = onCreateUserAccount;
 export const assignUserToEditingGroup = onAssignUserToEditingGroup;
 export const updatePermissions = onUpdatePermissions;
+export const requestDeleteDocument = onRequestDeleteDocument;
 
 /* Runs every Monday at 6AM PST */
 export const sendEditorStatsEmail = functions.pubsub.schedule('0 6 * * 1')

--- a/src/backend/config.ts
+++ b/src/backend/config.ts
@@ -15,6 +15,7 @@ export const MERGED_STATS_TEMPLATE = config?.sendgrid?.merged_stats_template;
 export const SUGGESTIONS_REVIEW_REMINDER_TEMPLATE = config?.sendgrid?.suggestions_review_reminder_template;
 export const NEW_USER_NOTIFICATION_TEMPLATE = config?.sendgrid?.new_user_notification_template;
 export const UPDATED_ROLE_NOTIFICATION = config?.sendgrid?.updated_role_notification;
+export const DOCUMENT_DELETION_REQUEST_NOTIFICATION = config?.sendgrid?.document_deletion_request_notification;
 export const API_FROM_EMAIL = config?.sendgrid?.sender_email;
 export const NKOWAOKWU_FROM_EMAIL = config?.sendgrid?.sender_email;
 

--- a/src/backend/controllers/email.ts
+++ b/src/backend/controllers/email.ts
@@ -9,6 +9,7 @@ import {
   SUGGESTIONS_REVIEW_REMINDER_TEMPLATE,
   NEW_USER_NOTIFICATION_TEMPLATE,
   UPDATED_ROLE_NOTIFICATION,
+  DOCUMENT_DELETION_REQUEST_NOTIFICATION,
 } from '../config';
 import { findAdminUserEmails } from './users';
 import * as Interfaces from './utils/interfaces';
@@ -34,9 +35,9 @@ export const sendEmail = (message: Interfaces.ConstructedMessage): Promise<void>
       console.log('Email successfully sent.');
     })
     .catch((err) => {
-      console.trace('sendEmail error:', err.response.body);
+      console.trace('sendEmail error:', err.response?.body || err.message);
       if (process.env.NODE_ENV !== 'production') {
-        return Promise.resolve(err.response.body);
+        return Promise.resolve(err.response?.body || err.message);
       }
       throw err;
     }) : (async () => {
@@ -103,7 +104,7 @@ export const sendSuggestionsReminder = async (data: Interfaces.SuggestionsRemind
 
 /* Emails admins about new user accounts */
 export const sendNewUserNotification = async (data: Interfaces.NewUserData): Promise<void> => {
-  const adminEmails = await findAdminUserEmails();
+  const adminEmails = await findAdminUserEmails() as [string];
   const message = constructMessage({
     from: { email: API_FROM_EMAIL, name: 'Igbo API' },
     to: adminEmails,
@@ -119,6 +120,19 @@ export const sendUpdatedRoleNotification = (
       from: { email: API_FROM_EMAIL, name: 'Igbo API' },
       to: data.to,
       templateId: UPDATED_ROLE_NOTIFICATION,
+      dynamic_template_data: omit(data, ['to']),
+    });
+    return sendEmail(message);
+  }
+);
+
+export const sendDocumentDeletionRequestNotification = (
+  async (data: Interfaces.DocumentDeletionRequestNotification): Promise<void> => {
+    const adminEmails = await findAdminUserEmails() as [string];
+    const message = constructMessage({
+      from: { email: API_FROM_EMAIL, name: 'Igbo API' },
+      to: adminEmails,
+      templateId: DOCUMENT_DELETION_REQUEST_NOTIFICATION,
       dynamic_template_data: omit(data, ['to']),
     });
     return sendEmail(message);

--- a/src/backend/controllers/utils/interfaces.ts
+++ b/src/backend/controllers/utils/interfaces.ts
@@ -126,7 +126,17 @@ export interface UpdatedRoleNotificationData {
   to: [string],
   displayName: string,
   role: Role,
-}
+};
+
+export interface DocumentDeletionRequestNotification {
+  translator: string,
+  translatorEmail: string,
+  note: string
+  resource: string,
+  id: string,
+  word: string,
+  definition: string,
+};
 
 export interface EmailMessage {
   from?: {

--- a/src/backend/functions/documents.ts
+++ b/src/backend/functions/documents.ts
@@ -1,0 +1,29 @@
+import * as functions from 'firebase-functions';
+import { sendDocumentDeletionRequestNotification } from '../controllers/email';
+
+/* Sends email to project admins to see request */
+export const onRequestDeleteDocument = functions.https.onCall(async (
+  { note, resource, record }:
+  {
+    note: string,
+    resource: string,
+    record: { id: string, word: string, definitions: [string] },
+  },
+  context,
+): Promise<Error | { redirect: boolean }> => {
+  try {
+    await sendDocumentDeletionRequestNotification({
+      translator: context.auth.token.name,
+      translatorEmail: context.auth.token.email,
+      note,
+      resource,
+      id: record.id,
+      word: record.word,
+      definition: record.definitions[0],
+    });
+    return { redirect: false };
+  } catch (err) {
+    console.log(err);
+    return err;
+  }
+});

--- a/src/shared/components/ConfirmModal/ConfirmModal.tsx
+++ b/src/shared/components/ConfirmModal/ConfirmModal.tsx
@@ -1,5 +1,6 @@
 import React, { ReactElement } from 'react';
 import PropTypes from 'prop-types';
+import { noop } from 'lodash';
 import {
   AlertDialog,
   AlertDialogBody,
@@ -21,6 +22,7 @@ const ConfirmModal = ({
   confirmColorScheme,
   cancel,
   title,
+  isDisabled,
   children,
 }: ConfirmModalInterface): ReactElement => (
   <AlertDialog
@@ -47,8 +49,9 @@ const ConfirmModal = ({
         </Button>
         <Button
           colorScheme={confirmColorScheme}
-          onClick={onConfirm}
+          onClick={isDisabled ? noop : onConfirm}
           isLoading={isConfirming}
+          disabled={isDisabled}
           ml={3}
           data-test="confirmation-confirm-button"
         >
@@ -61,6 +64,11 @@ const ConfirmModal = ({
 
 ConfirmModal.propTypes = {
   onClose: PropTypes.func.isRequired,
+  isDisabled: PropTypes.bool,
+};
+
+ConfirmModal.defaultProps = {
+  isDisabled: false,
 };
 
 export default ConfirmModal;

--- a/src/shared/components/ConfirmModal/ConfirmModalInterface.ts
+++ b/src/shared/components/ConfirmModal/ConfirmModalInterface.ts
@@ -7,6 +7,7 @@ interface ConfirmModal {
   cancel: string,
   onConfirm: () => void,
   onClose: () => void,
+  isDisabled?: boolean,
   children: any,
 };
 

--- a/src/shared/components/Confirmation/InputIdForm.tsx
+++ b/src/shared/components/Confirmation/InputIdForm.tsx
@@ -1,0 +1,26 @@
+import React, { ReactElement } from 'react';
+import { Input } from '@chakra-ui/react';
+import { ConfirmationInputInterface } from './ConfirmationInterface';
+
+/* Custom form for taking in word ids */
+const InputIdForm = ({
+  onChange,
+  value,
+  onSubmit,
+  header,
+  ...rest
+} : ConfirmationInputInterface): ReactElement => (
+  <form onSubmit={onSubmit}>
+    <h1 className="text-gray-700 mb-2">{header}</h1>
+    <Input
+      required
+      className="h-10 w-full lg:w-64 bg-gray-300 px-4 rounded-lg border border-solid border-gray-400"
+      type="text"
+      value={value}
+      onChange={onChange}
+      {...rest}
+    />
+  </form>
+);
+
+export default InputIdForm;

--- a/src/shared/components/Confirmation/InputNoteForm.tsx
+++ b/src/shared/components/Confirmation/InputNoteForm.tsx
@@ -1,0 +1,26 @@
+import React, { ReactElement } from 'react';
+import { Textarea } from '@chakra-ui/react';
+import { ConfirmationInputInterface } from './ConfirmationInterface';
+
+/* Custom form for taking in notes */
+const InputNoteForm = ({
+  onChange,
+  value,
+  onSubmit,
+  header,
+  ...rest
+}: ConfirmationInputInterface): ReactElement => (
+  <form onSubmit={onSubmit}>
+    <h1 className="text-gray-700 mb-2">{header}</h1>
+    <Textarea
+      required
+      className="h-10 w-full lg:w-64 bg-gray-300 px-4 rounded-lg border border-solid border-gray-400"
+      type="text"
+      value={value}
+      onChange={onChange}
+      {...rest}
+    />
+  </form>
+);
+
+export default InputNoteForm;

--- a/src/shared/components/Select/Select.tsx
+++ b/src/shared/components/Select/Select.tsx
@@ -12,6 +12,7 @@ import Select from 'react-select';
 import { withRouter } from 'react-router';
 import { connect } from 'react-redux';
 import { push } from 'react-router-redux';
+import ActionTypes from '../../constants/ActionTypes';
 import Confirmation from '../Confirmation';
 import { hasAdminOrMergerPermissions, hasAdminPermissions } from '../../utils/permissions';
 import { determineCreateSuggestionRedirection } from '../../utils';
@@ -147,6 +148,16 @@ const CustomSelect = ({
       label: 'Combine Word Into...',
       onSelect: ({ setAction }) => setAction(actionsMap.Combine),
     }] : null),
+    {
+      value: 'requestDelete',
+      label: (() => (
+        <span className="text-red-500">
+          <DeleteIcon className="mr-2" />
+          {`Request to Delete ${resource === Collection.WORDS ? 'Word' : 'Example'}`}
+        </span>
+      ))(),
+      onSelect: ({ setAction }) => setAction(actionsMap[ActionTypes.REQUEST_DELETE]),
+    },
   ]));
 
   const options = resource === Collection.USERS

--- a/src/shared/constants/ActionTypes.ts
+++ b/src/shared/constants/ActionTypes.ts
@@ -16,6 +16,7 @@ enum ActionTypes {
   COMBINE = 'Combine',
   ASSIGN_EDITING_GROUP = 'AssignEditingGroup',
   CONVERT = 'Convert',
+  REQUEST_DELETE = 'Send Delete Request',
   DELETE_USER = 'DeleteUser',
 };
 

--- a/src/shared/constants/actionsMap.ts
+++ b/src/shared/constants/actionsMap.ts
@@ -14,6 +14,7 @@ import ActionTypes from './ActionTypes';
 
 const handleUpdatePermissions = useCallable<string, EmptyResponse>('updatePermissions');
 const handleDeleteUser = useCallable<any, EmptyResponse>('deleteUser');
+const handleRequestDeleteDocument = useCallable<any, EmptyResponse>('requestDeleteDocument');
 
 export default {
   [ActionTypes.EDIT]: (resource: string, id: string): string => `/${resource}/${id}/edit`,
@@ -106,6 +107,18 @@ export default {
       return Promise.resolve();
     },
     successMessage: 'User role has been updated 👩🏾‍💻',
+  },
+  [ActionTypes.REQUEST_DELETE]: {
+    type: 'Send Delete Request',
+    title: 'Request to Delete Document',
+    content: 'Please explain why this document should be deleted. This note will be sent project admins for review.',
+    executeAction: (
+      { note, resource, record }:
+      { note: string, resource: string, record: Record },
+    ): Promise<any> => (
+      handleRequestDeleteDocument({ note, resource, record })
+    ),
+    successMessage: 'Your deletion request has been sent to admins 📨',
   },
   [ActionTypes.DELETE_USER]: {
     type: 'DeleteUser',


### PR DESCRIPTION
## Background
To increase communication between project admins and translators about deleting words in the database, the Igbo API Editor Platform now supports sending email notifications to project admins to delete requested words. This will empower translators to delegate more work to project admins to remove documents that translators don't have permission to delete.