### PR TITLE
Remove duplicate `requiresInput` variable

### DIFF
--- a/src/shared/components/Confirmation/Confirmation.tsx
+++ b/src/shared/components/Confirmation/Confirmation.tsx
@@ -38,13 +38,7 @@ const Confirmation = ({
   const refresh = useRefresh();
   const toast = useToast();
 
-  useFirebaseUid(setUid);  
-  
-  const requiresInput = (
-    action?.type === ActionTypes.REQUEST_DELETE
-    || action?.type === ActionTypes.ASSIGN_EDITING_GROUP
-    || action?.type === ActionTypes.ASSIGN_EDITING_GROUP
-  );
+  useFirebaseUid(setUid);
 
   const requiresInput = (
     action?.type === ActionTypes.REQUEST_DELETE


### PR DESCRIPTION
## Background
There were two instances of `requiresInput` in `Confirmation` due to a merge conflict.