### PR TITLE
Mock Firebase Firestore for Jest tests

### DIFF
--- a/__mocks__/firebase.ts
+++ b/__mocks__/firebase.ts
@@ -4,6 +4,12 @@ firebase.analytics = jest.fn().mockImplementation();
 firebase.auth = jest.fn(() => ({}));
 firebase.functions = jest.fn(() => ({
   httpsCallable: jest.fn(() => () => ({})),
+  useEmulator: jest.fn(() => ({})),
+}));
+firebase.firestore = jest.fn(() => ({
+  db: {
+    settings: jest.fn(() => ({})),
+  }
 }));
 firebase.auth.GoogleAuthProvider = jest.fn().mockImplementation();
 firebase.auth.FacebookAuthProvider = jest.fn().mockImplementation();


### PR DESCRIPTION
## Background
Jest tests in GitHub Actions are failing because Firebase Firestore fields are not mocked.