### PR TITLE
Extend `isAsCompleteAsPossible` check

### DIFF
--- a/src/shared/components/views/components/WordEditForm/components/HeadwordForm/HeadwordForm.tsx
+++ b/src/shared/components/views/components/WordEditForm/components/HeadwordForm/HeadwordForm.tsx
@@ -15,9 +15,25 @@ const HeadwordForm = ({
     record.word
     && record.wordClass
     && Array.isArray(record.definitions) && record.definitions.length
-    && Array.isArray(record.examples) && record.examples.length
+    && (
+      Array.isArray(record.examples)
+      && record.examples.length
+      && record.every(({ pronunciation }) => pronunciation)
+    )
+    && (
+      Object.entries(record.dialects)
+      && Object.entries(record.dialects).length
+      && Object.values(record.dialects).every(({ dialects, pronunciation }) => (
+        dialects.length && pronunciation
+      ))
+    )
     && record.pronunciation
     && record.isStandardIgbo
+    && record.nsibidi
+    && Array.isArray(record.stems) && record.stems.length
+    && Array.isArray(record.synonyms) && record.synonyms.length
+    && Array.isArray(record.antonyms) && record.antonyms.length
+
   );
 
   return (


### PR DESCRIPTION
## Background
The Is Complete check needs to check for all "complete" word criteria before being enabled