### PR TITLE
Fix Sufficient Word Count

### DIFF
--- a/src/shared/components/views/components/WordEditForm/components/HeadwordForm/HeadwordForm.tsx
+++ b/src/shared/components/views/components/WordEditForm/components/HeadwordForm/HeadwordForm.tsx
@@ -18,7 +18,7 @@ const HeadwordForm = ({
     && (
       Array.isArray(record.examples)
       && record.examples.length
-      && record.every(({ pronunciation }) => pronunciation)
+      && record.examples.every(({ pronunciation }) => pronunciation)
     )
     && (
       Object.entries(record.dialects)


### PR DESCRIPTION
## Bug Fixes
* Correctly count the "sufficient" words by reverting the old counting logic
* Call `every` on `record.examples` instead of just the `record` object