### PR TITLE
Check if audio is available and show in word status badge

### DIFF
--- a/src/backend/controllers/utils/determineDocumentCompleteness.ts
+++ b/src/backend/controllers/utils/determineDocumentCompleteness.ts
@@ -37,7 +37,7 @@ export default (record: Word | Record) : {
     !nsibidi && 'Nsịbịdị is needed',
     !stems?.length && 'A word stem is needed',
     !synonyms?.length && 'A synonym is needed',
-    !antonyms?.length && 'A antonym is needed',
+    !antonyms?.length && 'An antonym is needed',
     (Array.isArray(examples)
       && examples.some(({ pronunciation }) => !pronunciation)
       && 'All example sentences need pronunciations'

--- a/src/shared/components/CompleteWordPreview/determineIsAudioAvailable.ts
+++ b/src/shared/components/CompleteWordPreview/determineIsAudioAvailable.ts
@@ -1,0 +1,47 @@
+import axios from 'axios';
+import { Record } from 'react-admin';
+import { compact } from 'lodash';
+import { Word } from 'src/backend/controllers/utils/interfaces';
+
+export default async (record: Word | Record, callback: (value: any) => void): Promise<any> => {
+  const pronunciationsPromises = Object.entries(record).reduce((finalPronunciationsPromises, [key, value]) => {
+    if (key === 'pronunciation' && value) {
+      return [
+        ...finalPronunciationsPromises,
+        axios.get(record.pronunciation)
+          .then(() => ({ pronunciation: true }))
+          .catch(() => ({ pronunciation: false })),
+      ];
+    }
+    if (key === 'dialects') {
+      const dialectsPronunciationsPromises = Object.entries(record.dialects)
+        .reduce((
+          finalDialectsPronunciationPromises: any[],
+          [dialectKey, dialectValue] : [string, { pronunciation: string }],
+        ) => {
+          if (dialectValue?.pronunciation) {
+            return [
+              ...finalDialectsPronunciationPromises,
+              axios.get(dialectValue?.pronunciation)
+                .then(() => ({
+                  dialect: {
+                    [dialectKey]: true,
+                  },
+                }))
+                .catch(() => ({
+                  dialect: {
+                    [dialectKey]: false,
+                  },
+                })),
+            ];
+          }
+          return null;
+        }, []);
+      return finalPronunciationsPromises.concat(dialectsPronunciationsPromises);
+    }
+    return finalPronunciationsPromises;
+  }, []);
+
+  const resolvedPronunciations = await Promise.all(pronunciationsPromises);
+  callback(compact(resolvedPronunciations));
+};


### PR DESCRIPTION
## Background
The word document status badges now tell the user if audio recordings need to be rerecorded for any reason. This PR also changes the complete badge to be yellow if a word is prematurely marked as complete.

## Updated Badges
![Screen Shot 2022-03-06 at 9 59 07 AM](https://user-images.githubusercontent.com/16169291/156928862-4aef6b1f-747b-4bae-83e4-3ffde03332c6.png)

![Screen Shot 2022-03-06 at 9 59 02 AM](https://user-images.githubusercontent.com/16169291/156928863-6c24b765-d8ce-4b99-a46e-7f0ee820d2f6.png)
_Prematurely marked complete badge will be yellow instead of solid green_

![Screen Shot 2022-03-06 at 9 58 58 AM](https://user-images.githubusercontent.com/16169291/156928864-7724d52c-20a5-4c0d-bf64-01e98d045286.png)

