### PR TITLE
Forcefully uncheck isComplete if word document meet criteria

### DIFF
--- a/src/shared/components/CompleteWordPreview/CompleteWordPreview.tsx
+++ b/src/shared/components/CompleteWordPreview/CompleteWordPreview.tsx
@@ -52,33 +52,40 @@ const CompleteWordPreview = (
             ? ' Despite the document\'s status, the platform detects that there are more fields to be filled'
             : ''}
         </Text>
-        {requirements.length ? (
-          <Text fontWeight="bold" my="2">The following metadata are required for completion:</Text>
-        ) : ''}
-        <UnorderedList>
-          {
-            availableAudioStatuses?.length
-            && availableAudioStatuses.some((audioStatus) => audioStatus.pronunciation === false) ? (
-              <ListItem key="requirement-rerecord">The headword audio pronunciation needs to be rerecorded</ListItem>
-              ) : null
-          }
-          {requirements.map((requirement) => (
-            <ListItem key={`requirement-${requirement}`}>{requirement}</ListItem>
-          ))}
-          {
-            dialectStatusIndex !== -1
-            && Object.entries(availableAudioStatuses[dialectStatusIndex] || {}).map(([dialect, dialectAudioStatus]) => {
-              if (!dialectAudioStatus) {
-                return null;
+        {!showFull ? (
+          <>
+            {requirements.length ? (
+              <Text fontWeight="bold" my="2">The following metadata are required for completion:</Text>
+            ) : ''}
+            <UnorderedList>
+              {
+                availableAudioStatuses?.length
+                && availableAudioStatuses.some((audioStatus) => audioStatus.pronunciation === false) ? (
+                  <ListItem key="requirement-rerecord">
+                    The headword audio pronunciation needs to be rerecorded
+                  </ListItem>
+                  ) : null
               }
-              return (
-                <ListItem key={`requirement-${dialect}`}>
-                  {`The dialect variation "${dialect}" audio pronunciation needs to be rerecorded`}
-                </ListItem>
-              );
-            })
-          }
-        </UnorderedList>
+              {requirements.map((requirement) => (
+                <ListItem key={`requirement-${requirement}`}>{requirement}</ListItem>
+              ))}
+              {
+                dialectStatusIndex !== -1
+                && Object.entries(availableAudioStatuses[dialectStatusIndex] || {})
+                  .map(([dialect, dialectAudioStatus]) => {
+                    if (!dialectAudioStatus) {
+                      return null;
+                    }
+                    return (
+                      <ListItem key={`requirement-${dialect}`}>
+                        {`The dialect variation "${dialect}" audio pronunciation needs to be rerecorded`}
+                      </ListItem>
+                    );
+                  })
+                }
+            </UnorderedList>
+          </>
+        ) : null}
       </>
     );
   };
@@ -92,7 +99,7 @@ const CompleteWordPreview = (
   return (
     <Box data-test="pronunciation-cell" className={className}>
       <Tooltip
-        label={!showFull ? <TooltipLabel /> : null}
+        label={<TooltipLabel showFull={showFull} />}
         aria-label="A tooltip"
         backgroundColor={recommendRevisiting ? 'yellow.200' : documentStatus.tooltipColor}
         color="gray.600"

--- a/src/shared/components/views/components/WordEditForm/components/HeadwordForm/HeadwordForm.tsx
+++ b/src/shared/components/views/components/WordEditForm/components/HeadwordForm/HeadwordForm.tsx
@@ -55,7 +55,7 @@ const HeadwordForm = ({
                     onChange={(e) => onChange(e.target.checked)}
                     isChecked={value}
                     isDisabled={!isAsCompleteAsPossible}
-                    defaultIsChecked={record.isComplete}
+                    defaultIsChecked={isAsCompleteAsPossible && record.isComplete}
                     ref={ref}
                     data-test="isComplete-checkbox"
                     size="lg"
@@ -63,7 +63,7 @@ const HeadwordForm = ({
                     <span className="font-bold">Is Complete</span>
                   </Checkbox>
                 )}
-                defaultValue={record.isComplete || getValues().isComplete}
+                defaultValue={isAsCompleteAsPossible && (record.isComplete || getValues().isComplete)}
                 name="isComplete"
                 control={control}
               />


### PR DESCRIPTION
## Background
The Is Complete checkbox was disabled, disallowing editors to click on it to mark a word as incomplete if it's technically not complete. This PR enhances the editor platform so that it will automatically uncheck the "Is Complete" checkbox if the word document doesn't meet the criteria of being considered as complete.