### PR TITLE
Use isAccented to track if a headword is accented

### DIFF
--- a/src/backend/controllers/stats.ts
+++ b/src/backend/controllers/stats.ts
@@ -78,6 +78,7 @@ const countSufficientWords = (words) => (
     isStandardIgbo,
     pronunciation,
     examples,
+    isAccented,
     isComplete,
   }) => {
     const automaticCheck = (
@@ -85,7 +86,7 @@ const countSufficientWords = (words) => (
       // String normalization check:
       // https://www.codegrepper.com/code-examples/javascript/check+if+word+has+accented+or+unaccented+javascript
       // Filtering character in regex code: https://regex101.com/r/mL0eG4/1
-      && word.normalize('NFD').match(/(?!\u0323)[\u0300-\u036f]/g)
+      && (word.normalize('NFD').match(/(?!\u0323)[\u0300-\u036f]/g) || isAccented)
       && wordClass
       && Array.isArray(definitions) && definitions.length >= 1
       && Array.isArray(examples) && examples.length >= 1

--- a/src/backend/controllers/utils/buildDocs.ts
+++ b/src/backend/controllers/utils/buildDocs.ts
@@ -91,7 +91,7 @@ export const findWordsWithMatch = async (
       antonyms: 1,
       hypernyms: 1,
       hyponyms: 1,
-      isComplete: 1,
+      isAccented: 1,
       nsibidi: 1,
       ...(examples ? { examples: 1 } : {}),
     })

--- a/src/backend/controllers/utils/determineDocumentCompleteness.ts
+++ b/src/backend/controllers/utils/determineDocumentCompleteness.ts
@@ -15,6 +15,7 @@ export default (record: Word | Record) : {
     isStandardIgbo,
     pronunciation,
     examples = [],
+    isAccented,
     isComplete,
     nsibidi,
     stems = [],
@@ -25,7 +26,8 @@ export default (record: Word | Record) : {
 
   const sufficientWordRequirements = compact([
     !word && 'The headword is needed',
-    !word.normalize('NFD').match(/(?!\u0323)[\u0300-\u036f]/g) && 'The headword needs to have accent marks',
+    (!word.normalize('NFD').match(/(?!\u0323)[\u0300-\u036f]/g) && !isAccented)
+    && 'The headword needs to have accent marks',
     !wordClass && 'The word class is needed',
     Array.isArray(definitions) && !definitions.length && 'At least one definition is needed',
     Array.isArray(examples) && !examples?.length && 'At least one example sentence is needed',

--- a/src/backend/controllers/utils/determineIsAsCompleteAsPossible.ts
+++ b/src/backend/controllers/utils/determineIsAsCompleteAsPossible.ts
@@ -5,6 +5,7 @@ import { Word } from './interfaces';
 export default (word: Word | Record): boolean => !!(
   word.word
   && word.wordClass
+  && (word.word.normalize('NFD').match(/(?!\u0323)[\u0300-\u036f]/g) || word.isAccented)
   && Array.isArray(word.definitions) && word.definitions.length
   && (
     Array.isArray(word.examples)

--- a/src/backend/models/GenericWord.ts
+++ b/src/backend/models/GenericWord.ts
@@ -28,6 +28,7 @@ const genericWordSchema = new Schema({
   },
   pronunciation: { type: String, default: '' },
   isStandardIgbo: { type: Boolean, default: false },
+  isAccented: { type: Boolean, default: false },
   variations: { type: [{ type: String }], default: [] },
   editorsNotes: { type: String, default: '' },
   userComments: { type: String, default: '' },

--- a/src/backend/models/Word.ts
+++ b/src/backend/models/Word.ts
@@ -33,6 +33,7 @@ const wordSchema = new Schema({
   },
   pronunciation: { type: String, default: '' },
   isStandardIgbo: { type: Boolean, default: false },
+  isAccented: { type: Boolean, default: false },
   variations: { type: [{ type: String }], default: [] },
   frequency: { type: Number },
   stems: { type: [{ type: String }], default: [] },

--- a/src/backend/models/WordSuggestion.ts
+++ b/src/backend/models/WordSuggestion.ts
@@ -40,6 +40,7 @@ const wordSuggestionSchema = new Schema(
     },
     pronunciation: { type: String, default: '' },
     isStandardIgbo: { type: Boolean, default: false },
+    isAccented: { type: Boolean, default: false },
     variations: { type: [{ type: String }], default: [] },
     editorsNotes: { type: String, default: '' },
     userComments: { type: String, default: '' },

--- a/src/shared/components/views/components/WordEditForm/WordEditFormResolver.ts
+++ b/src/shared/components/views/components/WordEditForm/WordEditFormResolver.ts
@@ -29,6 +29,7 @@ const schema = yup.object().shape({
   antonyms: yup.array().min(0).of(yup.string()),
   pronunciation: yup.string().optional(),
   examples: yup.array().min(0).of(ExampleEditFormSchema),
+  isAccented: yup.boolean(),
   isComplete: yup.boolean(),
   nsibidi: yup.string(),
 });

--- a/src/shared/components/views/components/WordEditForm/components/HeadwordForm/HeadwordForm.tsx
+++ b/src/shared/components/views/components/WordEditForm/components/HeadwordForm/HeadwordForm.tsx
@@ -12,8 +12,8 @@ const HeadwordForm = ({
   record,
   getValues,
 }: HeadwordInterface): ReactElement => {
+  const isHeadwordAccented = (record.word || '').normalize('NFD').match(/(?!\u0323)[\u0300-\u036f]/g);
   const isAsCompleteAsPossible = determineIsAsCompleteAsPossible(record);
-
   return (
     <Box className="flex flex-col w-full">
       <Box className="flex flex-col lg:flex-row my-4 lg:my-0 space-y-2 lg:space-y-0 justify-between items-between">
@@ -54,17 +54,16 @@ const HeadwordForm = ({
                   <Checkbox
                     onChange={(e) => onChange(e.target.checked)}
                     isChecked={value}
-                    isDisabled={!isAsCompleteAsPossible}
-                    defaultIsChecked={isAsCompleteAsPossible && record.isComplete}
+                    defaultIsChecked={isHeadwordAccented && record.isAccented}
                     ref={ref}
-                    data-test="isComplete-checkbox"
+                    data-test="isAccented-checkbox"
                     size="lg"
                   >
-                    <span className="font-bold">Is Complete</span>
+                    <span className="font-bold">Is Accented</span>
                   </Checkbox>
                 )}
-                defaultValue={isAsCompleteAsPossible && (record.isComplete || getValues().isComplete)}
-                name="isComplete"
+                defaultValue={isHeadwordAccented && (record.isAccented || getValues().isAccented)}
+                name="isAccented"
                 control={control}
               />
             </Box>

--- a/src/shared/components/views/shows/WordShow/WordShow.tsx
+++ b/src/shared/components/views/shows/WordShow/WordShow.tsx
@@ -63,6 +63,7 @@ const WordShow = (props: ShowProps): ReactElement => {
     editorsNotes,
     userComments,
     isStandardIgbo,
+    isAccented,
     merged,
     pronunciation,
     originalWordId,
@@ -117,6 +118,13 @@ const WordShow = (props: ShowProps): ReactElement => {
                     path="isStandardIgbo"
                     diffRecord={diffRecord}
                     fallbackValue={isStandardIgbo}
+                    renderNestedObject={(value) => <span>{String(value)}</span>}
+                  />
+                  <Heading fontSize="lg" className="text-xl text-gray-600">Is Accented</Heading>
+                  <DiffField
+                    path="isAccented"
+                    diffRecord={diffRecord}
+                    fallbackValue={isAccented}
                     renderNestedObject={(value) => <span>{String(value)}</span>}
                   />
                 </Box>


### PR DESCRIPTION
## Background
The number of "sufficient" words has been going down due to the Igbo API Editor Platform automatically deselecting `isComplete` if a word doesn't meet all "complete" word criteria. This PR replaces the "Is Complete" checkbox with an "Is Accented" checkbox that will be checked automatically if the headword includes an accent mark. If a word doesn't include any visible accent marks but is correctly tone marked (meaning that the word doesn't need any tone marks) then the editor should check "Is Accented".

## New Is Accented checkbox
<img width="764" alt="Screen Shot 2022-03-08 at 7 59 28 AM" src="https://user-images.githubusercontent.com/16169291/157243574-b8e3a700-7b2f-47c6-96f3-c5b441e505d7.png">

