### PR TITLE
Dashboard Stats + Tenses

### DIFF
--- a/src/Core/Error/Error.tsx
+++ b/src/Core/Error/Error.tsx
@@ -27,7 +27,7 @@ const Error = ({ errorInfo }: { errorInfo: any }): ReactElement => (
         </Link>
       </Text>
       {process.env.NODE_ENV !== 'production' && (
-        <Accordion allowMultiple className="w-full my-6">
+        <Accordion defaultIndex={[0]} allowMultiple className="w-full my-6">
           <AccordionItem>
             <AccordionButton>
               <Box className="w-full flex flex-row items-center">

--- a/src/Core/constants.ts
+++ b/src/Core/constants.ts
@@ -6,10 +6,10 @@ export const VOICE_OVER_RECORDERS_SLACK_CHANNEL = 'https://igboapi.slack.com/arc
 export const EDITORS_TRANSLATORS_SLACK_CHANNEL = 'https://igboapi.slack.com/archives/C01UZQDDJ73';
 export const SOFTWARE_ENGINEERS_SLACK_CHANNEL = 'https://igboapi.slack.com/archives/C01UCDVSP0U';
 
-export const SUFFICIENT_WORDS_GOAL = 8095;
-export const COMPLETE_WORDS_GOAL = 8095;
+export const SUFFICIENT_WORDS_GOAL = 8100;
+export const COMPLETE_WORDS_GOAL = 8100;
 export const DIALECTAL_VARIATIONS_GOAL = 25000;
-export const HEADWORD_AUDIO_PRONUNCIATION_GOAL = 2700;
-export const WORDS_WITH_NSIBIDI_GOAL = 1000;
-export const IS_STANDARD_IGBO_GOAL = 1700;
-export const EXAMPLE_SENTENCES_GOAL = 4000;
+export const HEADWORD_AUDIO_PRONUNCIATION_GOAL = 3000;
+export const WORDS_WITH_NSIBIDI_GOAL = 2500;
+export const IS_STANDARD_IGBO_GOAL = 2500;
+export const EXAMPLE_SENTENCES_GOAL = 6000;

--- a/src/Login.tsx
+++ b/src/Login.tsx
@@ -96,6 +96,7 @@ const Login = (): ReactElement => {
       <Heading size="xl" className="mb-6">{'Igbo API Editor\'s Platform'}</Heading>
       <Box
         className="w-11/12 lg:w-8/12 xl:w-1/2 h-auto bg-white shadow-md rounded"
+        maxWidth="750px"
       >
         <Box
           className="h-full flex flex-col lg:flex-row space-y-2 lg:space-y-0 lg:space-x-2 lg:items-center rounded"

--- a/src/backend/controllers/utils/buildDocs.ts
+++ b/src/backend/controllers/utils/buildDocs.ts
@@ -93,6 +93,7 @@ export const findWordsWithMatch = async (
       hyponyms: 1,
       isAccented: 1,
       nsibidi: 1,
+      tenses: 1,
       ...(examples ? { examples: 1 } : {}),
     })
     .skip(skip)

--- a/src/backend/controllers/utils/determineDocumentCompleteness.ts
+++ b/src/backend/controllers/utils/determineDocumentCompleteness.ts
@@ -1,7 +1,9 @@
 import { compact } from 'lodash';
 import { Record } from 'react-admin';
 import { Word } from 'src/backend/controllers/utils/interfaces';
-import WordClass from 'src/shared/constants/WordClass';
+import Tense from 'src/backend/shared/constants/Tense';
+import WordClass from 'src/backend/shared/constants/WordClass';
+import isVerb from 'src/backend/shared/utils/isVerb';
 
 export default (record: Word | Record) : {
   sufficientWordRequirements: string[],
@@ -22,6 +24,7 @@ export default (record: Word | Record) : {
     synonyms = [],
     antonyms = [],
     dialects = {},
+    tenses = {},
   } = record;
 
   const sufficientWordRequirements = compact([
@@ -39,8 +42,13 @@ export default (record: Word | Record) : {
     ...sufficientWordRequirements,
     !nsibidi && 'Nsịbịdị is needed',
     !stems?.length && 'A word stem is needed',
-    word.wordClass === WordClass.NNP.value ? null : !synonyms?.length && 'A synonym is needed',
-    word.wordClass === WordClass.NNP.value ? null : !antonyms?.length && 'An antonym is needed',
+    wordClass === WordClass.NNP.value ? null : !synonyms?.length && 'A synonym is needed',
+    wordClass === WordClass.NNP.value ? null : !antonyms?.length && 'An antonym is needed',
+    isVerb(wordClass) && !Object.entries(tenses).every(([key, value]) => (
+      value && Object.values(Tense).find(({ value: tenseValue }) => key === tenseValue)
+    ))
+      ? 'All verb tenses are needed'
+      : null,
     (Array.isArray(examples)
       && examples.some(({ pronunciation }) => !pronunciation)
       && 'All example sentences need pronunciations'

--- a/src/backend/models/GenericWord.ts
+++ b/src/backend/models/GenericWord.ts
@@ -3,6 +3,7 @@ import { every, has, partial } from 'lodash';
 import Dialects from '../shared/constants/Dialects';
 import { toJSONPlugin, toObjectPlugin } from './plugins/index';
 import * as Interfaces from '../controllers/utils/interfaces';
+import Tense from '../shared/constants/Tense';
 
 const REQUIRED_DIALECT_KEYS = ['word', 'variations', 'dialect', 'pronunciation'];
 const REQUIRED_DIALECT_CONSTANT_KEYS = ['code', 'value', 'label'];
@@ -25,6 +26,17 @@ const genericWordSchema = new Schema({
         && dialectValue.dialect === Dialects[dialectValue.dialect].value
       ));
     },
+  },
+  tenses: {
+    type: Object,
+    validate: (v) => {
+      const tenseValues = Object.values(Tense);
+      Object.keys(v).every((key) => (
+        tenseValues.find(({ value: tenseValue }) => key === tenseValue)
+      ));
+    },
+    required: false,
+    default: {},
   },
   pronunciation: { type: String, default: '' },
   isStandardIgbo: { type: Boolean, default: false },

--- a/src/backend/models/Word.ts
+++ b/src/backend/models/Word.ts
@@ -2,6 +2,7 @@ import mongoose from 'mongoose';
 import { every, has, partial } from 'lodash';
 import Dialects from '../shared/constants/Dialects';
 import { toJSONPlugin, toObjectPlugin } from './plugins';
+import Tense from '../shared/constants/Tense';
 import WordClass from '../shared/constants/WordClass';
 import * as Interfaces from '../controllers/utils/interfaces';
 
@@ -31,6 +32,17 @@ const wordSchema = new Schema({
     required: false,
     default: {},
   },
+  tenses: {
+    type: Object,
+    validate: (v) => {
+      const tenseValues = Object.values(Tense);
+      Object.keys(v).every((key) => (
+        tenseValues.find(({ value: tenseValue }) => key === tenseValue)
+      ));
+    },
+    required: false,
+    default: {},
+  },
   pronunciation: { type: String, default: '' },
   isStandardIgbo: { type: Boolean, default: false },
   isAccented: { type: Boolean, default: false },
@@ -44,6 +56,28 @@ const wordSchema = new Schema({
   isComplete: { type: Boolean, default: false },
   nsibidi: { type: String, default: '' },
 }, { toObject: toObjectPlugin, timestamps: true });
+
+// const tensesIndexes = Object.values(Tense).reduce((finalIndexes, tense) => ({
+//   ...finalIndexes,
+//   [`tenses.${tense.value}`]: 'text',
+// }), {});
+
+// wordSchema.index({
+//   word: 'text',
+//   variations: 'text',
+//   dialects: 'text',
+//   ...tensesIndexes,
+//   nsibidi: 'text',
+// }, {
+//   weights: {
+//     word: 10,
+//     tenses: 9,
+//     dialects: 8,
+//     vairations: 9,
+//     nsibidi: 5,
+//   },
+//   name: 'Word text index',
+// });
 
 wordSchema.index({ word: 'text', variations: 'text', nsibidi: 'text' });
 

--- a/src/backend/models/WordSuggestion.ts
+++ b/src/backend/models/WordSuggestion.ts
@@ -5,6 +5,7 @@ import Dialects from '../shared/constants/Dialects';
 import { toJSONPlugin, toObjectPlugin } from './plugins';
 import { uploadWordPronunciation } from './plugins/pronunciationHooks';
 import * as Interfaces from '../controllers/utils/interfaces';
+import Tense from '../shared/constants/Tense';
 import WordClass from '../shared/constants/WordClass';
 
 const REQUIRED_DIALECT_KEYS = ['variations', 'dialects', 'pronunciation'];
@@ -33,6 +34,17 @@ const wordSuggestionSchema = new Schema(
           && every(dialectValue.dialects, (dialect) => Dialects[dialect].value)
           && typeof dialectValue.pronunciation === 'string'
           && Array.isArray(dialectValue.variations)
+        ));
+      },
+      required: false,
+      default: {},
+    },
+    tenses: {
+      type: Object,
+      validate: (v) => {
+        const tenseValues = Object.values(Tense);
+        Object.keys(v).every((key) => (
+          tenseValues.find(({ value: tenseValue }) => key === tenseValue)
         ));
       },
       required: false,

--- a/src/backend/shared/constants/Tense.ts
+++ b/src/backend/shared/constants/Tense.ts
@@ -1,0 +1,30 @@
+/**
+ * This file defines the valid tenses options for words and wordSuggestions
+ */
+
+export default {
+  INFINITIVE: {
+    value: 'infinitive',
+    label: 'Infinitive',
+  },
+  IMPERATIVE: {
+    value: 'imperative',
+    label: 'Imperative',
+  },
+  SIMPLE_PAST: {
+    value: 'simplePast',
+    label: 'Simple Past',
+  },
+  SIMPLE_PRESENT: {
+    value: 'simplePresent',
+    label: 'Simple Present',
+  },
+  PRESENT_CONTINUOUS: {
+    value: 'presentContinuous',
+    label: 'Present Continuous',
+  },
+  FUTURE: {
+    value: 'future',
+    label: 'Future',
+  },
+};

--- a/src/backend/shared/utils/isVerb.ts
+++ b/src/backend/shared/utils/isVerb.ts
@@ -1,0 +1,9 @@
+import WordClass from '../constants/WordClass';
+
+const isVerb = (wordClass: string): boolean => (
+  wordClass === WordClass.AV.value
+  || wordClass === WordClass.PV.value
+  || wordClass === WordClass.MV.value
+);
+
+export default isVerb;

--- a/src/shared/components/views/components/FormHeader.tsx
+++ b/src/shared/components/views/components/FormHeader.tsx
@@ -1,14 +1,25 @@
 import React, { ReactElement } from 'react';
+import { noop } from 'lodash';
 import { Box, Tooltip } from '@chakra-ui/react';
 import { InfoOutlineIcon } from '@chakra-ui/icons';
 
-const FormHeader = ({ title, tooltip } : { title: string, tooltip: string }): ReactElement => (
-  <Box className="flex flex-row items-center">
-    <h2 className="form-header">{title}</h2>
+const FormHeader = (
+  { title, tooltip, onClick }
+  : { title: string, tooltip: string, onClick?: () => any },
+): ReactElement => (
+  <Box
+    className={`flex flex-row items-center${onClick ? ' cursor-pointer' : ''}`}
+    onClick={onClick || noop}
+  >
+    <h2 className={`form-header${onClick ? ' hover:underline' : ''}`}>{title}</h2>
     <Tooltip label={tooltip}>
       <InfoOutlineIcon color="gray.600" className="ml-2" />
     </Tooltip>
   </Box>
 );
+
+FormHeader.defaultProps = {
+  onClick: null,
+};
 
 export default FormHeader;

--- a/src/shared/components/views/components/WordEditForm/WordEditForm.tsx
+++ b/src/shared/components/views/components/WordEditForm/WordEditForm.tsx
@@ -19,6 +19,7 @@ import WordClass from 'src/shared/constants/WordClass';
 import { getWord } from 'src/shared/API';
 import useBeforeWindowUnload from 'src/hooks/useBeforeWindowUnload';
 import { Word, WordDialect } from 'src/backend/controllers/utils/interfaces';
+import isVerb from 'src/backend/shared/utils/isVerb';
 import WordEditFormResolver from './WordEditFormResolver';
 import { sanitizeArray, onCancel } from '../utils';
 import DefinitionsForm from './components/DefinitionsForm';
@@ -29,6 +30,7 @@ import AntonymsForm from './components/AntonymsForm';
 import PartOfSpeechForm from './components/PartOfSpeechForm';
 import HeadwordForm from './components/HeadwordForm';
 import NsibidiForm from './components/NsibidiForm';
+import TensesForm from './components/TensesForm';
 import ExamplesForm from './components/ExamplesForm';
 import AudioRecorder from '../AudioRecorder';
 import CurrentDialectsForms from './components/CurrentDialectForms/CurrentDialectsForms';
@@ -52,6 +54,7 @@ const WordEditForm = ({
     setValue,
     control,
     errors,
+    watch,
   } = useForm({
     defaultValues: {
       dialects: record.dialects,
@@ -66,6 +69,7 @@ const WordEditForm = ({
       antonyms: record.antonyms || [],
       stems: record.stems || [],
       nsibidi: record.nsibidi,
+      tenses: record.tenses || {},
     },
     ...WordEditFormResolver(),
   });
@@ -84,6 +88,7 @@ const WordEditForm = ({
   const redirect = useRedirect();
   const toast = useToast();
   const options = values(WordClass);
+  const watchWordClass = watch('wordClass');
 
   /* Gets the original example id and associated words to prepare to send to the API */
   const sanitizeExamples = (examples = []) => {
@@ -277,6 +282,13 @@ const WordEditForm = ({
               errors={errors}
               control={control}
             />
+            {isVerb(watchWordClass.value) ? (
+              <TensesForm
+                record={record}
+                errors={errors}
+                control={control}
+              />
+            ) : null}
           </Box>
           <Box className="flex flex-col w-full lg:w-1/2">
             <VariationsForm

--- a/src/shared/components/views/components/WordEditForm/WordEditFormResolver.ts
+++ b/src/shared/components/views/components/WordEditForm/WordEditFormResolver.ts
@@ -1,5 +1,6 @@
 import { yupResolver } from '@hookform/resolvers/yup';
 import * as yup from 'yup';
+import Tense from 'src/backend/shared/constants/Tense';
 import { ExampleEditFormSchema } from '../ExampleEditForm/ExampleEditFormResolver';
 
 const schema = yup.object().shape({
@@ -24,6 +25,10 @@ const schema = yup.object().shape({
     variations: yup.array().min(0).of(yup.string()).optional(),
     pronunciation: yup.string().optional(),
   }),
+  tenses: yup.object().shape(Object.values(Tense).reduce((finalSchema, tenseValue) => ({
+    ...finalSchema,
+    [tenseValue.value]: yup.string().optional(),
+  }), {})).optional(),
   stems: yup.array().min(0).of(yup.string()),
   synonyms: yup.array().min(0).of(yup.string()),
   antonyms: yup.array().min(0).of(yup.string()),

--- a/src/shared/components/views/components/WordEditForm/components/DefinitionsForm/DefinitionsForm.tsx
+++ b/src/shared/components/views/components/WordEditForm/components/DefinitionsForm/DefinitionsForm.tsx
@@ -73,9 +73,9 @@ const DefinitionsForm = ({
         </Box>
       </Box>
     ))}
-    {errors.definitions && (
+    {errors.definitions ? (
       <p className="error relative">Definition is required</p>
-    )}
+    ) : null}
   </Box>
 );
 export default DefinitionsForm;

--- a/src/shared/components/views/components/WordEditForm/components/HeadwordForm/HeadwordForm.tsx
+++ b/src/shared/components/views/components/WordEditForm/components/HeadwordForm/HeadwordForm.tsx
@@ -68,6 +68,9 @@ const HeadwordForm = ({
               />
             </Box>
           </Tooltip>
+          {errors.isAccented ? (
+            <p className="error relative">Is Accented must be selected</p>
+          ) : null}
         </Box>
       </Box>
       <Controller

--- a/src/shared/components/views/components/WordEditForm/components/TensesForm/TensesForm.tsx
+++ b/src/shared/components/views/components/WordEditForm/components/TensesForm/TensesForm.tsx
@@ -1,0 +1,60 @@
+import React, { ReactElement } from 'react';
+import { capitalize } from 'lodash';
+import { Controller } from 'react-hook-form';
+import { Box } from '@chakra-ui/react';
+import { Input } from 'src/shared/primitives';
+import Tense from 'src/backend/shared/constants/Tense';
+import FormHeader from '../../../FormHeader';
+import TensesFormInterface from './TensesFormInterface';
+
+const DEFAULT_TENSES = Object.values(Tense).reduce((finalTenses, tense) => ({
+  ...finalTenses,
+  [tense.value]: '',
+}), {});
+const TENSES_DOC = 'https://www.notion.so/Verb-Conjugation-Rules-1a37590fdfca42518ee5ea2d049229a9';
+
+const TensesForm = ({
+  record,
+  errors,
+  control,
+}: TensesFormInterface): ReactElement => (
+  <Box className="w-full">
+    <FormHeader
+      title="Tenses"
+      tooltip="Common verb conjugations (tenses) for the given word. Click here to see verb conjugation rules."
+      onClick={() => {
+        window.open(TENSES_DOC, '_blank');
+      }}
+    />
+    {Object.entries(record.tenses || DEFAULT_TENSES).map(([key, value]) => (
+      <>
+        <Controller
+          render={({ onChange, ref }) => {
+            const label = capitalize(key.replace(/([A-Z])/g, ' $1'));
+            return (
+              <>
+                <h3 className="text-gray-700 mb-2">{`${label}:`}</h3>
+                <Input
+                  onChange={(e) => onChange(e.target.value)}
+                  defaultValue={record?.tenses?.[key]}
+                  placeholder={label}
+                  ref={ref}
+                  data-test={`tenses-${key}-input`}
+                  mb={4}
+                />
+              </>
+            );
+          }}
+          defaultValue={value}
+          name={`tenses.${key}`}
+          control={control}
+        />
+        {errors.tenses?.[key] ? (
+          <p className="error relative">Fill in associated tense</p>
+        ) : null}
+      </>
+    ))}
+  </Box>
+);
+
+export default TensesForm;

--- a/src/shared/components/views/components/WordEditForm/components/TensesForm/TensesFormInterface.ts
+++ b/src/shared/components/views/components/WordEditForm/components/TensesForm/TensesFormInterface.ts
@@ -1,0 +1,10 @@
+import { Record } from 'react-admin';
+import { Control } from 'react-hook-form';
+
+interface HeadwordForm {
+  record: Record,
+  errors: any,
+  control: Control,
+};
+
+export default HeadwordForm;

--- a/src/shared/components/views/components/WordEditForm/components/TensesForm/index.ts
+++ b/src/shared/components/views/components/WordEditForm/components/TensesForm/index.ts
@@ -1,0 +1,3 @@
+import TensesForm from './TensesForm';
+
+export default TensesForm;

--- a/src/shared/components/views/shows/WordShow/WordShow.tsx
+++ b/src/shared/components/views/shows/WordShow/WordShow.tsx
@@ -22,6 +22,7 @@ import DiffField from '../diffFields/DiffField';
 import ArrayDiffField from '../diffFields/ArrayDiffField';
 import ExampleDiff from '../diffFields/ExampleDiff';
 import ArrayDiff from '../diffFields/ArrayDiff';
+import TenseDiff from '../diffFields/TenseDiff';
 
 const DIFF_FILTER_KEYS = [
   'id',
@@ -281,13 +282,22 @@ const WordShow = (props: ShowProps): ReactElement => {
                   <Comments editorsNotes={editorsNotes} userComments={userComments} />
                 ) : null}
               </Box>
-              <Box className="flex flex-col mt-5">
-                <Heading fontSize="lg" className="text-xl text-gray-600">Dialects</Heading>
-                <DialectDiff
-                  record={record}
-                  diffRecord={diffRecord}
-                  resource={resource}
-                />
+              <Box className="flex flex-col space-y-6 mt-5">
+                <Box>
+                  <Heading fontSize="lg" className="text-xl text-gray-600 mb-2">Dialects</Heading>
+                  <DialectDiff
+                    record={record}
+                    diffRecord={diffRecord}
+                    resource={resource}
+                  />
+                </Box>
+                <Box>
+                  <Heading fontSize="lg" className="text-xl text-gray-600 mb-2">Tenses</Heading>
+                  <TenseDiff
+                    record={record}
+                    resource={resource}
+                  />
+                </Box>
               </Box>
             </Box>
           </Box>

--- a/src/shared/components/views/shows/diffFields/DialectDiff.tsx
+++ b/src/shared/components/views/shows/diffFields/DialectDiff.tsx
@@ -8,7 +8,9 @@ import {
   AccordionIcon,
   AccordionPanel,
   Box,
+  Heading,
   Spinner,
+  chakra,
 } from '@chakra-ui/react';
 import ReactAudioPlayer from 'react-audio-player';
 import Dialects from 'src/backend/shared/constants/Dialects';
@@ -28,9 +30,9 @@ const DialectDiff = (
     <Box className="w-full">
       {updatedDialects.length ? updatedDialects.map(({ value, label }) => (
         <>
-          <h1 className="text-xl mt-3">{label}</h1>
+          <Heading as="h1" className="text-xl mt-3">{label}</Heading>
           <Box className="flex flex-row items-center">
-            <h2 className="text-lg">Word:</h2>
+            <Heading as="h2" className="text-lg">Word:</Heading>
             <DiffField
               path={`dialects.${value}.dialects`}
               diffRecord={diffRecord}
@@ -47,7 +49,7 @@ const DialectDiff = (
                   style={{ height: 40, width: 250 }}
                   controls
                 />
-              ) : <span>No audio pronunciation</span>}
+              ) : <chakra.span>No audio pronunciation</chakra.span>}
               renderNestedObject={() => (
                 <ReactAudioPlayer
                   src={record.dialects[value].pronunciation}
@@ -60,7 +62,7 @@ const DialectDiff = (
         </>
       )) : resource === Collection.WORDS || resource === Collection.WORD_SUGGESTIONS ? (
         <Accordion
-          defaultIndex={0}
+          defaultIndex={[0]}
           allowMultiple
         >
           {Object.entries(record.dialects as Interfaces.WordDialect).map(([
@@ -72,27 +74,25 @@ const DialectDiff = (
             },
           ], index) => (
             <AccordionItem key={index}>
-              <h2>
-                <AccordionButton>
-                  <Box flex="1" textAlign="left">
-                    {dialectalWord}
-                  </Box>
-                  <AccordionIcon />
-                </AccordionButton>
-              </h2>
+              <AccordionButton>
+                <Heading as="h2" size="sm" className="text-left">
+                  {dialectalWord}
+                </Heading>
+                <AccordionIcon />
+              </AccordionButton>
               <AccordionPanel pb={4} className="space-y-3">
-                <h2>
-                  <span className="font-bold mr-2">Dialects:</span>
-                  <ul style={{ listStyle: 'inside' }}>
-                    {dialects.map((dialect) => (
-                      <li>{Dialects[dialect].label}</li>
-                    ))}
-                  </ul>
-                </h2>
-                <h2>
-                  <span className="font-bold mr-2">Variations:</span>
-                  {variations.length ? variations.join(', ') : 'No variations'}
-                </h2>
+                <Heading as="h2" size="sm" className="text-left mr-2">Dialects:</Heading>
+                <ul style={{ listStyle: 'inside' }}>
+                  {dialects.map((dialect) => (
+                    <li>{Dialects[dialect].label}</li>
+                  ))}
+                </ul>
+                <Heading as="h2" size="sm" className="text-left">
+                  <chakra.span className="mr-2">Variations:</chakra.span>
+                  <chakra.span fontWeight="normal" className="mr-2">
+                    {variations.length ? variations.join(', ') : 'No variations'}
+                  </chakra.span>
+                </Heading>
                 <ReactAudioPlayer
                   src={pronunciation}
                   style={{ height: 40, width: 250 }}
@@ -103,9 +103,9 @@ const DialectDiff = (
           ))}
         </Accordion>
       ) : (
-        <span className="text-gray-500 italic">
+        <chakra.span className="text-gray-500 italic">
           No dialect changes
-        </span>
+        </chakra.span>
       )}
     </Box>
   ) : <Spinner />;

--- a/src/shared/components/views/shows/diffFields/TenseDiff.tsx
+++ b/src/shared/components/views/shows/diffFields/TenseDiff.tsx
@@ -1,0 +1,56 @@
+/* eslint-disable react/no-array-index-key */
+import React, { ReactElement } from 'react';
+import { capitalize } from 'lodash';
+import { Record } from 'react-admin';
+import {
+  Accordion,
+  AccordionItem,
+  AccordionButton,
+  AccordionIcon,
+  AccordionPanel,
+  Box,
+  Heading,
+  Spinner,
+  Text,
+  chakra,
+} from '@chakra-ui/react';
+import Collection from 'src/shared/constants/Collections';
+
+/* Renders the visual red/green diff sections in the Show view */
+const TenseDiff = (
+  { record: propRecord, resource }:
+  { record: Record, resource: string },
+): ReactElement => {
+  const record = { ...(propRecord || {}), tenses: propRecord?.tenses || {} };
+  // @ts-ignore
+  return record?.word ? (
+    <Box className="w-full">
+      {resource === Collection.WORDS || resource === Collection.WORD_SUGGESTIONS ? (
+        <Accordion
+          defaultIndex={[0]}
+          allowMultiple
+        >
+          {Object.entries(record.tenses).map(([tenseKey, tenseValue]) => (
+            <AccordionItem key={tenseKey}>
+              <AccordionButton>
+                <Heading as="h2" size="sm" className="text-left">
+                  {capitalize(tenseKey.replace(/([A-Z])/g, ' $1'))}
+                </Heading>
+                <AccordionIcon />
+              </AccordionButton>
+              <AccordionPanel pb={4} className="space-y-3">
+                <Text>{tenseValue}</Text>
+              </AccordionPanel>
+            </AccordionItem>
+          ))}
+        </Accordion>
+      ) : (
+        <chakra.span className="text-gray-500 italic">
+          No tense changes
+        </chakra.span>
+      )}
+    </Box>
+  ) : <Spinner />;
+};
+
+export default TenseDiff;

--- a/src/shared/constants/WordClass.ts
+++ b/src/shared/constants/WordClass.ts
@@ -1,7 +1,7 @@
 /**
  * This file defines the valid wordClass options for words and wordSuggestions
  */
-const WordClass = {
+export default {
   ADJ: {
     value: 'ADJ',
     label: 'Adjective',
@@ -83,5 +83,3 @@ const WordClass = {
     label: 'Punctuations',
   },
 };
-
-export default WordClass;


### PR DESCRIPTION
## Background
This PR updates the dashboard stats with the [new Q2 goals](https://www.notion.so/2022-Q2-Project-Role-Roadmap-cc1da9851fde4a7493c3d710e6e73913). Additionally, this PR supports editing the new [`tenses`](https://github.com/ijemmao/igbo_api/pull/449) field that pertains to verbs (active, passive, and medial).

## Tenses section
<img width="547" alt="Screen Shot 2022-04-07 at 7 40 54 PM" src="https://user-images.githubusercontent.com/16169291/162337369-3f8f77e0-6843-48d4-9a1f-ab9c9beda2a9.png">
